### PR TITLE
Set file separators to forward slash

### DIFF
--- a/WEB-INF/classes/com/cohort/util/File2.java
+++ b/WEB-INF/classes/com/cohort/util/File2.java
@@ -220,7 +220,7 @@ public class File2 {
      * THIS IS ONLY INTENDED FOR USE DURING TESTS.
      */
     public static void setWebInfParentDirectory() {
-        webInfParentDirectory =  System.getProperty("user.dir") + "\\";
+        webInfParentDirectory = System.getProperty("user.dir") + "/";
     }
 
     /**

--- a/src/test/java/testDataset/Initialization.java
+++ b/src/test/java/testDataset/Initialization.java
@@ -8,7 +8,7 @@ import gov.noaa.pfel.erddap.dataset.EDD;
 public class Initialization {
   public static void edStatic() {
     File2.setWebInfParentDirectory();
-    System.setProperty("erddapContentDirectory", System.getProperty("user.dir") + "\\content\\erddap");
+    System.setProperty("erddapContentDirectory", System.getProperty("user.dir") + "/content/erddap");
     System.setProperty("doSetupValidation", String.valueOf(false));
     EDD.debugMode = true;
     System.setProperty("useSansSerifFont", String.valueOf(true));


### PR DESCRIPTION
Change file separators for `File2.setWebInfParentDirectory` and `Initialization.edStatic.erddapContentDirectory` to forward slashes (`/`) for *nix compatibility. If this causes problems on Windows we'll need to use Java's `File.separator`.