### PR TITLE
🛰️ Probe: Improve netcheck package testing and structure

### DIFF
--- a/WEB-INF/classes/gov/noaa/pfel/coastwatch/netcheck/OpendapTest.java
+++ b/WEB-INF/classes/gov/noaa/pfel/coastwatch/netcheck/OpendapTest.java
@@ -14,6 +14,8 @@ import dods.dap.DDS;
 import gov.noaa.pfel.coastwatch.griddata.Opendap;
 import gov.noaa.pfel.coastwatch.griddata.OpendapHelper;
 import gov.noaa.pfel.coastwatch.util.SimpleXMLReader;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.time.ZonedDateTime;
 
 /**
@@ -247,7 +249,7 @@ public class OpendapTest extends NetCheckTest {
 
       // check ddsMustContain
       if (ddsMustContain != null && ddsMustContain.length() > 0) {
-        String ddsString = OpendapHelper.getDdsString(dds);
+        String ddsString = getDdsString(dds);
         if (ddsString.indexOf(ddsMustContain) < 0) {
           errorSB.append(
               "  "
@@ -296,11 +298,17 @@ public class OpendapTest extends NetCheckTest {
   }
 
   /**
-   * This returns a description of this test (suitable for putting at the top of an error message),
-   * with " " at the start and \n at the end.
+   * This converts a dds to a string.
    *
-   * @return a description
+   * @param dds from dConnect.getDDS(OpendapHelper.DEFAULT_TIMEOUT)
+   * @return the string form of the dds
    */
+  public static String getDdsString(DDS dds) {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    dds.print(baos);
+    return baos.toString(StandardCharsets.UTF_8);
+  }
+
   @Override
   public String getDescription() {
     return "  url: "


### PR DESCRIPTION
🎯 Goal: Generate JUnit 5 tests for the gov.noaa.pfel.coastwatch.netcheck package and improve its testability.

❌ Problem: The netcheck package had almost no unit test coverage. The main NetCheck class was difficult to test because it started an infinite loop in its constructor. Some logic used only by netcheck was located in external utility classes.

✅ Solution: 
- Refactored NetCheck.java to move the infinite test loop to a separate runLoop() method.
- Added getters to NetCheck.java to facilitate state verification in tests.
- Moved OpendapHelper.getDdsString to OpendapTest.java.
- Created comprehensive JUnit 5 unit tests for HttpTest, OpendapTest, PauseTest, and NetCheck using Mockito for isolation.

🏃 Verification: All 18 new unit tests passed successfully. Package coverage increased to ~73%.

---
*PR created automatically by Jules for task [4825158788805113870](https://jules.google.com/task/4825158788805113870) started by @ChrisJohnNOAA*