### PR TITLE
Refactor file system ID retrieval in SharedWatchService

### DIFF
--- a/WEB-INF/classes/gov/noaa/pfel/coastwatch/util/SharedWatchService.java
+++ b/WEB-INF/classes/gov/noaa/pfel/coastwatch/util/SharedWatchService.java
@@ -6,6 +6,7 @@ import com.cohort.util.String2;
 import java.io.IOException;
 import java.nio.file.FileStore;
 import java.nio.file.FileSystem;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardWatchEventKinds;

--- a/WEB-INF/classes/gov/noaa/pfel/coastwatch/util/SharedWatchService.java
+++ b/WEB-INF/classes/gov/noaa/pfel/coastwatch/util/SharedWatchService.java
@@ -95,14 +95,23 @@ public class SharedWatchService {
   }
 
   private static String systemToID(FileSystem system) {
-    if (system == FileSystems.getDefault()) {
-        // Restore the "one service for the machine" behavior 
-        // without calling the dangerous getFileStores()
-        return "default";
+    // 1. Use the Provider name to group by OS implementation (e.g., Linux vs. Jimfs).
+    String provider = system.provider().getClass().getName();
+
+    // 2. Get the primary root (e.g., "/" on Linux).
+    // This is fast and non-blocking.
+    String rootStr = "";
+    try {
+        Iterable<Path> roots = system.getRootDirectories();
+        if (roots != null && roots.iterator().hasNext()) {
+            rootStr = roots.iterator().next().toString();
+        }
+    } catch (Exception e) {
+        // Fallback to identity if roots can't be accessed
+        rootStr = Integer.toHexString(System.identityHashCode(system));
     }
-    // For non-default file systems (like Jimfs in tests), 
-    // use the hash code to keep it unique but safe.
-    return "fs:" + system.hashCode();
+
+    return provider + ":" + rootStr;
   }
 
   /**

--- a/WEB-INF/classes/gov/noaa/pfel/coastwatch/util/SharedWatchService.java
+++ b/WEB-INF/classes/gov/noaa/pfel/coastwatch/util/SharedWatchService.java
@@ -61,7 +61,7 @@ public class SharedWatchService {
     if (fs == null)
       throw new RuntimeException("getFileSystem returned null for the " + watchDir + " path.");
 
-    String fsId = SharedWatchService.systemToID(fs);
+    String fsId = SharedWatchService.getFileStoreId(watchPath);
 
     WatchService watchService = null;
     if (fileSystemToService.containsKey(fsId)) {
@@ -93,12 +93,20 @@ public class SharedWatchService {
     keyToHandlerId.put(key, handler);
   }
 
-  private static String systemToID(FileSystem system) {
-    StringBuilder id = new StringBuilder();
-    for (FileStore store : system.getFileStores()) {
-      id.append(store.name()).append(store.type());
+  private static String getFileStoreId(Path path) throws IOException {
+    FileStore store = Files.getFileStore(path);
+    // On Linux/Unix, 'unix:dev' is the most unique identifier for a partition.
+    // It is much safer than store.name() which can be duplicated.
+    try {
+        Object devId = store.getAttribute("unix:dev");
+        if (devId != null) {
+            return store.type() + ":" + devId.toString();
+        }
+    } catch (IllegalArgumentException e) {
+        // Fallback for non-Unix systems or if the attribute isn't supported
     }
-    return id.toString();
+    // Secondary fallback: use name and type of ONLY this specific store
+    return store.name() + store.type();
   }
 
   /**

--- a/WEB-INF/classes/gov/noaa/pfel/coastwatch/util/SharedWatchService.java
+++ b/WEB-INF/classes/gov/noaa/pfel/coastwatch/util/SharedWatchService.java
@@ -6,7 +6,6 @@ import com.cohort.util.String2;
 import java.io.IOException;
 import java.nio.file.FileStore;
 import java.nio.file.FileSystem;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardWatchEventKinds;
@@ -62,7 +61,7 @@ public class SharedWatchService {
     if (fs == null)
       throw new RuntimeException("getFileSystem returned null for the " + watchDir + " path.");
 
-    String fsId = SharedWatchService.getFileStoreId(watchPath);
+    String fsId = SharedWatchService.systemToId(fs);
 
     WatchService watchService = null;
     if (fileSystemToService.containsKey(fsId)) {
@@ -94,20 +93,15 @@ public class SharedWatchService {
     keyToHandlerId.put(key, handler);
   }
 
-  private static String getFileStoreId(Path path) throws IOException {
-    FileStore store = Files.getFileStore(path);
-    // On Linux/Unix, 'unix:dev' is the most unique identifier for a partition.
-    // It is much safer than store.name() which can be duplicated.
-    try {
-        Object devId = store.getAttribute("unix:dev");
-        if (devId != null) {
-            return store.type() + ":" + devId.toString();
-        }
-    } catch (IllegalArgumentException e) {
-        // Fallback for non-Unix systems or if the attribute isn't supported
+  private static String systemToID(FileSystem system) {
+    if (system == FileSystems.getDefault()) {
+        // Restore the "one service for the machine" behavior 
+        // without calling the dangerous getFileStores()
+        return "default";
     }
-    // Secondary fallback: use name and type of ONLY this specific store
-    return store.name() + store.type();
+    // For non-default file systems (like Jimfs in tests), 
+    // use the hash code to keep it unique but safe.
+    return "fs:" + system.hashCode();
   }
 
   /**

--- a/WEB-INF/classes/gov/noaa/pfel/coastwatch/util/SharedWatchService.java
+++ b/WEB-INF/classes/gov/noaa/pfel/coastwatch/util/SharedWatchService.java
@@ -6,6 +6,7 @@ import com.cohort.util.String2;
 import java.io.IOException;
 import java.nio.file.FileStore;
 import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardWatchEventKinds;

--- a/WEB-INF/classes/gov/noaa/pfel/coastwatch/util/SharedWatchService.java
+++ b/WEB-INF/classes/gov/noaa/pfel/coastwatch/util/SharedWatchService.java
@@ -61,7 +61,7 @@ public class SharedWatchService {
     if (fs == null)
       throw new RuntimeException("getFileSystem returned null for the " + watchDir + " path.");
 
-    String fsId = SharedWatchService.systemToId(fs);
+    String fsId = SharedWatchService.systemToID(fs);
 
     WatchService watchService = null;
     if (fileSystemToService.containsKey(fsId)) {


### PR DESCRIPTION
# Description

Avoid iterating over FileStores, this can hang some system configurations.

Fixes issue were certain system configurations would hang when trying to set up the watch service.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
