### PR TITLE
Fix SQL syntax error for non-database column requests in EDDTableFromDatabase

### DIFF
--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromDatabase.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromDatabase.java
@@ -734,8 +734,8 @@ public class EDDTableFromDatabase extends EDDTable {
       TableWriter tableWriter)
       throws Throwable {
 
-    if (handleViaFixedOrSubsetVariables(language, loggedInAs, requestUrl, userDapQuery, tableWriter))
-      return;
+    if (handleViaFixedOrSubsetVariables(
+        language, loggedInAs, requestUrl, userDapQuery, tableWriter)) return;
 
     // good summary of using statements, queries, resultSets, ...
     //  https://docs.oracle.com/javase/7/docs/api/java/sql/ResultSet.html
@@ -870,12 +870,11 @@ public class EDDTableFromDatabase extends EDDTable {
       // then ensure needOtherSourceNames are in resultsVariables
       for (String sourceName : needOtherSourceNames) {
         if (sourceNamesSet.add(sourceName)) // if not already present
-          resultsVariables.add(sourceName);
+        resultsVariables.add(sourceName);
       }
     }
 
     // no need to further prune constraints
-
 
     // make the connection
     Connection connection = null;
@@ -1094,12 +1093,12 @@ public class EDDTableFromDatabase extends EDDTable {
         tableColToRsCol[rv] =
             rs.findColumn(tName); // stored as 1..    throws Throwable if not found
       }
-      int triggerNRows =
-          EDStatic.config.partialRequestMaxCells / Math.max(1, resultsEDVs.length);
+      int triggerNRows = EDStatic.config.partialRequestMaxCells / Math.max(1, resultsEDVs.length);
       Table table = makeEmptySourceTable(resultsEDVs, triggerNRows);
       PrimitiveArray paArray[] = new PrimitiveArray[nRv];
       for (int rv = 0; rv < nRv; rv++) paArray[rv] = table.getColumn(rv);
-      PrimitiveArray dummyPa = nRv == 0 ? PrimitiveArray.factory(PAType.INT, triggerNRows, false) : null;
+      PrimitiveArray dummyPa =
+          nRv == 0 ? PrimitiveArray.factory(PAType.INT, triggerNRows, false) : null;
 
       // process the resultSet rows of data
       while (true) {

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromDatabase.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromDatabase.java
@@ -734,6 +734,9 @@ public class EDDTableFromDatabase extends EDDTable {
       TableWriter tableWriter)
       throws Throwable {
 
+    if (handleViaFixedOrSubsetVariables(language, loggedInAs, requestUrl, userDapQuery, tableWriter))
+      return;
+
     // good summary of using statements, queries, resultSets, ...
     //  https://docs.oracle.com/javase/7/docs/api/java/sql/ResultSet.html
 
@@ -867,11 +870,12 @@ public class EDDTableFromDatabase extends EDDTable {
       // then ensure needOtherSourceNames are in resultsVariables
       for (String sourceName : needOtherSourceNames) {
         if (sourceNamesSet.add(sourceName)) // if not already present
-        resultsVariables.add(sourceName);
+          resultsVariables.add(sourceName);
       }
     }
 
     // no need to further prune constraints
+
 
     // make the connection
     Connection connection = null;
@@ -946,17 +950,21 @@ public class EDDTableFromDatabase extends EDDTable {
       StringBuilder query = new StringBuilder();
       int nRv = resultsVariables.size();
       String distinctString = distinct ? "DISTINCT " : "";
-      for (int rv = 0; rv < nRv; rv++)
-        // no danger of sql injection since query has been parsed and
-        //  resultsVariables must be known sourceNames
-        // Note that I tried to use '?' for resultsVariables, but never got it to work: wierd
-        // results.
-        // Quotes around colNames avoid trouble when colName is a SQL reserved word.
-        query.append(
-            (rv == 0 ? "SELECT " + distinctString : ", ")
-                + columnNameQuotes
-                + resultsVariables.get(rv)
-                + columnNameQuotes);
+      if (nRv == 0) {
+        query.append("SELECT " + distinctString + "1");
+      } else {
+        for (int rv = 0; rv < nRv; rv++)
+          // no danger of sql injection since query has been parsed and
+          //  resultsVariables must be known sourceNames
+          // Note that I tried to use '?' for resultsVariables, but never got it to work: wierd
+          // results.
+          // Quotes around colNames avoid trouble when colName is a SQL reserved word.
+          query.append(
+              (rv == 0 ? "SELECT " + distinctString : ", ")
+                  + columnNameQuotes
+                  + resultsVariables.get(rv)
+                  + columnNameQuotes);
+      }
       // Lack of quotes around table names means they can't be SQL reserved words.
       // (If do quote in future, quote individual parts.)
       query.append(
@@ -1086,16 +1094,21 @@ public class EDDTableFromDatabase extends EDDTable {
         tableColToRsCol[rv] =
             rs.findColumn(tName); // stored as 1..    throws Throwable if not found
       }
-      int triggerNRows = EDStatic.config.partialRequestMaxCells / resultsEDVs.length;
+      int triggerNRows =
+          EDStatic.config.partialRequestMaxCells / Math.max(1, resultsEDVs.length);
       Table table = makeEmptySourceTable(resultsEDVs, triggerNRows);
       PrimitiveArray paArray[] = new PrimitiveArray[nRv];
       for (int rv = 0; rv < nRv; rv++) paArray[rv] = table.getColumn(rv);
+      PrimitiveArray dummyPa = nRv == 0 ? PrimitiveArray.factory(PAType.INT, triggerNRows, false) : null;
 
       // process the resultSet rows of data
       while (true) {
         boolean hasNext = rs.next();
 
         if (hasNext) {
+          if (nRv == 0) {
+            dummyPa.addInt(1);
+          }
           for (int rv = 0; rv < nRv; rv++) {
             int rsCol = tableColToRsCol[rv];
             EDV edv = resultsEDVs[rv];
@@ -1137,20 +1150,30 @@ public class EDDTableFromDatabase extends EDDTable {
           }
         }
 
-        if ((paArray[0].size() > 0 && !hasNext) || paArray[0].size() >= triggerNRows) {
+        if (((nRv == 0 ? dummyPa.size() > 0 : paArray[0].size() > 0) && !hasNext)
+            || (nRv == 0 ? dummyPa.size() >= triggerNRows : paArray[0].size() >= triggerNRows)) {
           if (Thread.currentThread().isInterrupted())
             throw new SimpleException(
                 "EDDTableFromDatabase.getDataForDapQuery"
                     + EDStatic.messages.get(Message.CAUGHT_INTERRUPTED, 0));
 
           // convert script columns into data columns
-          if (scriptNames != null)
-            convertScriptColumnsToDataColumns(
-                "", table, scriptNames, scriptTypes, scriptNeedsColumns);
+          if (scriptNames != null) {
+            if (nRv == 0) {
+              // temporarily add dummy column so table.nRows() works
+              table.addColumn("dummy", dummyPa);
+              convertScriptColumnsToDataColumns(
+                  "", table, scriptNames, scriptTypes, scriptNeedsColumns);
+              table.removeColumn(0);
+            } else {
+              convertScriptColumnsToDataColumns(
+                  "", table, scriptNames, scriptTypes, scriptNeedsColumns);
+            }
+          }
 
           // String2.log(table.toString("rows",5));
           preStandardizeResultsTable(loggedInAs, table);
-          if (table.nRows() > 0) {
+          if (table.nRows() > 0 || (nRv == 0 && dummyPa.size() > 0 && scriptNames == null)) {
             standardizeResultsTable(
                 language,
                 requestUrl,
@@ -1162,6 +1185,7 @@ public class EDDTableFromDatabase extends EDDTable {
           if (hasNext) {
             table = makeEmptySourceTable(resultsEDVs, triggerNRows);
             for (int rv = 0; rv < nRv; rv++) paArray[rv] = table.getColumn(rv);
+            if (nRv == 0) dummyPa.clear();
           }
           if (tableWriter.noMoreDataPlease) {
             tableWriter.logCaughtNoMoreDataPlease(datasetID);

--- a/pom.xml
+++ b/pom.xml
@@ -846,6 +846,13 @@
         </dependency>
 
         <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>2.2.224</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
             <version>${jettyVersion}</version>

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDGridFromNcFilesTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDGridFromNcFilesTests.java
@@ -2461,8 +2461,8 @@ class EDDGridFromNcFilesTests {
             "            <att name=\"Grib2_Generating_Process_Type\">Forecast</att>\n"
             + "            <att name=\"Grib2_Level_Desc\">Ordered Sequence of Data</att>\n"
             + //// changed in
-              //// netcdf-java
-              //// 4.6.4
+            //// netcdf-java
+            //// 4.6.4
             "            <att name=\"Grib2_Level_Type\" type=\"int\">241</att>\n"
             + // changed in
             // netcdf-java 4.6.4

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromDatabaseBugTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromDatabaseBugTests.java
@@ -1,0 +1,198 @@
+package gov.noaa.pfel.erddap.dataset;
+
+import com.cohort.util.File2;
+import com.cohort.util.String2;
+import com.cohort.util.Test;
+import gov.noaa.pfel.coastwatch.pointdata.Table;
+import gov.noaa.pfel.erddap.util.EDStatic;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import testDataset.Initialization;
+
+class EDDTableFromDatabaseBugTests {
+
+  private static Connection keepAliveConn;
+
+  @BeforeAll
+  static void init() throws Exception {
+    Initialization.edStatic();
+    // Keep an in-memory H2 connection open for the duration of the tests
+    String url = "jdbc:h2:mem:test_bug;DB_CLOSE_DELAY=-1";
+    Class.forName("org.h2.Driver");
+    keepAliveConn = DriverManager.getConnection(url, "sa", "");
+    try (Statement stmt = keepAliveConn.createStatement()) {
+      stmt.execute("CREATE TABLE mytable (id INT PRIMARY KEY, name VARCHAR(255))");
+      stmt.execute("INSERT INTO mytable VALUES (1, 'Alice')");
+      stmt.execute("INSERT INTO mytable VALUES (2, 'Bob')");
+    }
+  }
+
+  @AfterAll
+  static void destroy() throws Exception {
+    if (keepAliveConn != null) {
+      keepAliveConn.close();
+    }
+  }
+
+  @org.junit.jupiter.api.Test
+  void testEmptySelectBug() throws Throwable {
+    String2.log("\n*** EDDTableFromDatabaseBugTests.testEmptySelectBug()");
+    String url = "jdbc:h2:mem:test_bug;DB_CLOSE_DELAY=-1";
+    String driver = "org.h2.Driver";
+
+    String xml =
+        "<dataset type=\"EDDTableFromDatabase\" datasetID=\"h2_test\" active=\"true\">\n"
+            + "    <sourceUrl>"
+            + url
+            + "</sourceUrl>\n"
+            + "    <driverName>"
+            + driver
+            + "</driverName>\n"
+            + "    <connectionProperty name=\"user\">sa</connectionProperty>\n"
+            + "    <connectionProperty name=\"password\"></connectionProperty>\n"
+            + "    <addAttributes>\n"
+            + "        <att name=\"title\">H2 Test</att>\n"
+            + "        <att name=\"summary\">H2 Test Summary</att>\n"
+            + "        <att name=\"institution\">H2 Test Institution</att>\n"
+            + "        <att name=\"infoUrl\">http://example.com</att>\n"
+            + "        <att name=\"cdm_data_type\">Other</att>\n"
+            + "    </addAttributes>\n"
+            + "    <tableName>mytable</tableName>\n"
+            + "    <columnNameQuotes></columnNameQuotes>\n"
+            + "    <dataVariable>\n"
+            + "        <sourceName>id</sourceName>\n"
+            + "        <destinationName>id</destinationName>\n"
+            + "        <dataType>int</dataType>\n"
+            + "        <addAttributes>\n"
+            + "            <att name=\"ioos_category\">Identifier</att>\n"
+            + "        </addAttributes>\n"
+            + "    </dataVariable>\n"
+            + "    <dataVariable>\n"
+            + "        <sourceName>=123</sourceName>\n"
+            + "        <destinationName>fixed_var</destinationName>\n"
+            + "        <dataType>int</dataType>\n"
+            + "        <addAttributes>\n"
+            + "            <att name=\"ioos_category\">Unknown</att>\n"
+            + "        </addAttributes>\n"
+            + "    </dataVariable>\n"
+            + "</dataset>";
+
+    EDDTable tedd = (EDDTable) EDDTableFromDatabase.oneFromXmlFragment(null, xml);
+    String dir = EDStatic.config.fullTestCacheDirectory;
+    int language = 0;
+
+    // Case 1: fixed_var ONLY. handleViaFixedOrSubsetVariables will handle this and return 1 row.
+    TableWriterAll twa = new TableWriterAll(language, tedd, null, dir, "testFixedVarOnly");
+    tedd.getDataForDapQuery(
+        language, EDStatic.loggedInAsSuperuser, "/erddap/tabledap/h2_test.csv", "fixed_var", twa);
+    Table table = twa.cumulativeTable();
+    String results = table.saveAsCsvASCIIString();
+    String expected =
+        "fixed_var\n" + "\n" + "123\n"; // handleViaFixedOrSubsetVariables returns 1 row
+    Test.ensureEqual(results, expected, "results=\n" + results);
+
+    // TEST: Constraint on id (database column) but not requested.
+    // resultsVariables should contain 'id', database should be queried, filtering should apply.
+    // Use a constraint on id to ensure it DOES go past handleViaFixedOrSubsetVariables if it wanted
+    // to,
+    // but resultsVariables will still be empty for the DB query if we don't request id.
+    twa = new TableWriterAll(language, tedd, null, dir, "testConstraintOnly");
+    tedd.getDataForDapQuery(
+        language,
+        EDStatic.loggedInAsSuperuser,
+        "/erddap/tabledap/h2_test.csv",
+        "fixed_var&id=2",
+        twa);
+    table = twa.cumulativeTable();
+    results = table.saveAsCsvASCIIString();
+    expected = "fixed_var\n\n123\n"; // Only 1 row (for Bob, id=2)
+    Test.ensureEqual(results, expected, "results=\n" + results);
+
+    // TEST: Negative constraint
+    twa = new TableWriterAll(language, tedd, null, dir, "testNegativeConstraint");
+    try {
+      tedd.getDataForDapQuery(
+          language,
+          EDStatic.loggedInAsSuperuser,
+          "/erddap/tabledap/h2_test.csv",
+          "fixed_var&id=100",
+          twa);
+      results = "shouldn't get here";
+    } catch (Throwable t) {
+      results = t.getMessage();
+    }
+    expected = "Your query produced no matching results. (nRows = 0)";
+    Test.ensureEqual(results, expected, "results=\n" + results);
+  }
+
+  @org.junit.jupiter.api.Test
+  void testAggregateRowsWithEmptySelectBug() throws Throwable {
+    String2.log("\n*** EDDTableFromDatabaseBugTests.testAggregateRowsWithEmptySelectBug()");
+    String url = "jdbc:h2:mem:test_bug;DB_CLOSE_DELAY=-1";
+    String driver = "org.h2.Driver";
+
+    String childXml =
+        "<dataset type=\"EDDTableFromDatabase\" datasetID=\"h2_child\" active=\"true\">\n"
+            + "    <sourceUrl>"
+            + url
+            + "</sourceUrl>\n"
+            + "    <driverName>"
+            + driver
+            + "</driverName>\n"
+            + "    <connectionProperty name=\"user\">sa</connectionProperty>\n"
+            + "    <connectionProperty name=\"password\"></connectionProperty>\n"
+            + "    <addAttributes>\n"
+            + "        <att name=\"title\">H2 Child</att>\n"
+            + "        <att name=\"summary\">H2 Child Summary</att>\n"
+            + "        <att name=\"institution\">H2 Child Institution</att>\n"
+            + "        <att name=\"infoUrl\">http://example.com</att>\n"
+            + "        <att name=\"cdm_data_type\">Other</att>\n"
+            + "    </addAttributes>\n"
+            + "    <tableName>mytable</tableName>\n"
+            + "    <columnNameQuotes></columnNameQuotes>\n"
+            + "    <dataVariable>\n"
+            + "        <sourceName>id</sourceName>\n"
+            + "        <destinationName>id</destinationName>\n"
+            + "        <dataType>int</dataType>\n"
+            + "        <addAttributes>\n"
+            + "            <att name=\"ioos_category\">Identifier</att>\n"
+            + "        </addAttributes>\n"
+            + "    </dataVariable>\n"
+            + "    <dataVariable>\n"
+            + "        <sourceName>=123</sourceName>\n"
+            + "        <destinationName>fixed_var</destinationName>\n"
+            + "        <dataType>int</dataType>\n"
+            + "        <addAttributes>\n"
+            + "            <att name=\"ioos_category\">Unknown</att>\n"
+            + "        </addAttributes>\n"
+            + "    </dataVariable>\n"
+            + "</dataset>";
+
+    String aggXml =
+        "<dataset type=\"EDDTableAggregateRows\" datasetID=\"h2_agg\" active=\"true\">\n"
+            + "    <addAttributes>\n"
+            + "        <att name=\"title\">H2 Agg</att>\n"
+            + "        <att name=\"summary\">H2 Agg Summary</att>\n"
+            + "        <att name=\"institution\">H2 Agg Institution</att>\n"
+            + "        <att name=\"infoUrl\">http://example.com</att>\n"
+            + "        <att name=\"cdm_data_type\">Other</att>\n"
+            + "    </addAttributes>\n"
+            + childXml
+            + "</dataset>";
+
+    EDDTable tedd = (EDDTable) EDDTableAggregateRows.oneFromXmlFragment(null, aggXml);
+    String dir = EDStatic.config.fullTestCacheDirectory;
+    int language = 0;
+
+    String query = "fixed_var&id=1";
+    String tName =
+        tedd.makeNewFileForDapQuery(
+            language, null, null, query, dir, "testAggregateRowsWithEmptySelectBug", ".csv");
+    String results = File2.directReadFrom88591File(dir + tName);
+    String expected = "fixed_var\n" + "\n" + "123\n";
+    Test.ensureEqual(results, expected, "results=\n" + results);
+  }
+}


### PR DESCRIPTION
🎯 Goal: Fix the "SELECT FROM table" syntax error in `EDDTableFromDatabase` (and by extension `EDDTableAggregateRows`) when a query requests only non-database columns (constants or scripts).

❌ Problem: If a user requested columns like `fixed_var` and provided a constraint like `id=1`, `EDDTableFromDatabase` would correctly push the constraint to the database, but since `fixed_var` is not a database column, `resultsVariables` would be empty, leading to invalid SQL.

✅ Solution: 
1. Call `handleViaFixedOrSubsetVariables` early to handle simple fixed-variable-only requests in memory.
2. If the request proceeds to the database part and has no database columns to select, use `SELECT 1` as a placeholder.
3. Use a temporary internal dummy column to correctly track the row count of the result set, which is necessary for ERDDAP's chunking and script variable logic.
4. Database-side filtering is fully maintained.

🏃 Verification: 
- Created an H2-based reproduction test suite covering various cases (fixed only, fixed with DB filters, aggregation).
- Verified that database constraints are still correctly applied even when no database columns are requested.
- Confirmed that original `EDDTableAggregateRowsTests` pass.

---
*PR created automatically by Jules for task [14045416862000382510](https://jules.google.com/task/14045416862000382510) started by @ChrisJohnNOAA*