### PR TITLE
Add .ncoJsonHeader output option

### DIFF
--- a/WEB-INF/classes/com/cohort/array/Attributes.java
+++ b/WEB-INF/classes/com/cohort/array/Attributes.java
@@ -923,6 +923,22 @@ public class Attributes {
    *     JSON, with a comma after the closing }.
    */
   public String toNcoJsonString(String indent) {
+    return toNcoJsonString(indent, true);
+  }
+
+  /**
+   * This writes the attributes for a variable (or *GLOBAL*) to a String using NCO JSON lvl=2
+   * pedantic style. See https://nco.sourceforge.net/nco.html#json This doesn't change any of the
+   * attributes. See issues in javadoc for EDDTable.saveAsNcoJson().
+   *
+   * <p>String attributes are written as type="char". See comments in EDDTable.
+   *
+   * @param indent a String a spaces for the start of each line
+   * @param trailingComma true if you want a comma after the closing }
+   * @return a string with all of the attributes for a variable (or *GLOBAL*) formatted for NCO
+   *     JSON.
+   */
+  public String toNcoJsonString(String indent, boolean trailingComma) {
     StringBuilder sb = new StringBuilder();
 
     // "attributes": {
@@ -986,7 +1002,8 @@ public class Attributes {
         (somethingWritten ? "\n" : "")
             + // end previous line
             indent
-            + "},\n");
+            + "}"
+            + (trailingComma ? ",\n" : "\n"));
     return sb.toString();
   }
 

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/filetypes/NcoJsonFiles.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/filetypes/NcoJsonFiles.java
@@ -50,7 +50,7 @@ public class NcoJsonFiles extends TableWriterFileType {
       throws Throwable {
     if (tableWriter instanceof TableWriterAllWithMetadata twalwm) {
       String jsonp = EDStatic.getJsonpFromQuery(requestInfo.language(), requestInfo.userDapQuery());
-      saveAsNcoJson(requestInfo.outputStream(), twalwm, jsonp);
+      saveAsNcoJson(requestInfo.outputStream(), twalwm, jsonp, true);
     }
   }
 
@@ -61,7 +61,8 @@ public class NcoJsonFiles extends TableWriterFileType {
         requestInfo.requestUrl(),
         requestInfo.userDapQuery(),
         requestInfo.outputStream(),
-        requestInfo.getEDDGrid());
+        requestInfo.getEDDGrid(),
+        true);
   }
 
   @Override
@@ -114,10 +115,14 @@ public class NcoJsonFiles extends TableWriterFileType {
    *     https://www.raymondcamden.com/2014/03/12/Reprint-What-in-the-heck-is-JSONP-and-why-would-you-use-it/
    *     . A SimpleException will be thrown if tJsonp is not null but isn't
    *     String2.isVariableNameSafe.
+   * @param writeValues true if you want the data values to be written.
    * @throws Throwable
    */
-  private void saveAsNcoJson(
-      OutputStreamSource outputStreamSource, TableWriterAllWithMetadata twawm, String jsonp)
+  protected void saveAsNcoJson(
+      OutputStreamSource outputStreamSource,
+      TableWriterAllWithMetadata twawm,
+      String jsonp,
+      boolean writeValues)
       throws Throwable {
     if (EDDTable.reallyVerbose) String2.log("EDDTable.saveAsNcoJson");
     long time = System.currentTimeMillis();
@@ -202,66 +207,65 @@ public class NcoJsonFiles extends TableWriterFileType {
                 + "      \"type\": \""
                 + tType
                 + "\",\n");
-        writer.write(atts.toNcoJsonString("      "));
-        writer.write("      \"data\": [");
-        try (DataInputStream dis = twawm.dataInputStream(col)) {
-          // create the bufferPA
-          PrimitiveArray pa = null;
-          long nRowsRead = 0;
-          while (nRowsRead < nRows) {
-            int nToRead = (int) Math.min(bufferSize, nRows - nRowsRead);
-            if (pa == null) {
-              pa = twawm.columnEmptyPA(col);
-              pa.ensureCapacity(nToRead);
+        writer.write(atts.toNcoJsonString("      ", writeValues));
+        if (writeValues) {
+          writer.write("      \"data\": [");
+          try (DataInputStream dis = twawm.dataInputStream(col)) {
+            // create the bufferPA
+            PrimitiveArray pa = null;
+            long nRowsRead = 0;
+            while (nRowsRead < nRows) {
+              int nToRead = (int) Math.min(bufferSize, nRows - nRowsRead);
+              if (pa == null) {
+                pa = twawm.columnEmptyPA(col);
+                pa.ensureCapacity(nToRead);
+              }
+              pa.clear();
+              pa.setMaxIsMV(twawm.columnMaxIsMV(col)); // reset after clear()
+              pa.readDis(dis, nToRead);
+              if (isChar) {
+                // write it as one string with chars concatenated
+                // see "md5_abc" in in http://dust.ess.uci.edu/tmp/in.json.fmt2
+                //  "shape": ["lev"],          //dim lev size=3
+                //  ...
+                //  "data": ["abc"]
+                // here: write it in buffersize chunks
+                if (nRowsRead == 0) writer.write("\""); // start the string
+                String s = String2.toJson(new String(((CharArray) pa).toArray()));
+                writer.write(s.substring(1, s.length() - 1)); // remove start and end "
+              } else if (isString) {
+                // Arrays of Strings are written oddly: (example from
+                // http://dust.ess.uci.edu/tmp/in.json.fmt2)
+                //    "date_rec": {
+                //      "shape": ["time", "char_dmn_lng26"],
+                //      "type": "char",
+                //      "attributes": ...,
+                //      "data": [["2010-11-01T00:00:00.000000"], ["2010-11-01T01:00:00.000000"],
+                // ["2010-11-01T02:00:00.000000"], ["2010-11-01T03:00:00.000000"],
+                // ["2010-11-01T04:00:00.000000"], ["2010-11-01T05:00:00.000000"],
+                // ["2010-11-01T06:00:00.000000"], ["2010-11-01T07:00:00.000000"],
+                // ["2010-11-01T08:00:00.000000"], ["2010-11-01T09:00:00.000000"]]
+                //    },
+                if (nRowsRead > 0) writer.write(",\n    "); // separate and write on next line
+                ssb.setLength(0);
+                for (int row = 0; row < nToRead; row++)
+                  ssb.append(
+                      (row == 0 ? "" : ", ")
+                          + stringOpenBracket
+                          + String2.toJson(pa.getString(row))
+                          + stringCloseBracket);
+                writer.write(ssb.toString());
+              } else {
+                if (nRowsRead > 0) writer.write(",\n    "); // separate and write on next line
+                writer.write(pa.toJsonCsvString());
+              }
+              nRowsRead += nToRead;
             }
-            pa.clear();
-            pa.setMaxIsMV(twawm.columnMaxIsMV(col)); // reset after clear()
-            pa.readDis(dis, nToRead);
-            if (isChar) {
-              // write it as one string with chars concatenated
-              // see "md5_abc" in in http://dust.ess.uci.edu/tmp/in.json.fmt2
-              //  "shape": ["lev"],          //dim lev size=3
-              //  ...
-              //  "data": ["abc"]
-              // here: write it in buffersize chunks
-              if (nRowsRead == 0) writer.write("\""); // start the string
-              String s = String2.toJson(new String(((CharArray) pa).toArray()));
-              writer.write(s.substring(1, s.length() - 1)); // remove start and end "
-            } else if (isString) {
-              // Arrays of Strings are written oddly: (example from
-              // http://dust.ess.uci.edu/tmp/in.json.fmt2)
-              //    "date_rec": {
-              //      "shape": ["time", "char_dmn_lng26"],
-              //      "type": "char",
-              //      "attributes": ...,
-              //      "data": [["2010-11-01T00:00:00.000000"], ["2010-11-01T01:00:00.000000"],
-              // ["2010-11-01T02:00:00.000000"], ["2010-11-01T03:00:00.000000"],
-              // ["2010-11-01T04:00:00.000000"], ["2010-11-01T05:00:00.000000"],
-              // ["2010-11-01T06:00:00.000000"], ["2010-11-01T07:00:00.000000"],
-              // ["2010-11-01T08:00:00.000000"], ["2010-11-01T09:00:00.000000"]]
-              //    },
-              if (nRowsRead > 0) writer.write(",\n    "); // separate and write on next line
-              ssb.setLength(0);
-              for (int row = 0; row < nToRead; row++)
-                ssb.append(
-                    (row == 0 ? "" : ", ")
-                        + stringOpenBracket
-                        + String2.toJson(pa.getString(row))
-                        + stringCloseBracket);
-              writer.write(ssb.toString());
-            } else {
-              if (nRowsRead > 0) writer.write(",\n    "); // separate and write on next line
-              writer.write(pa.toJsonCsvString());
-            }
-            nRowsRead += nToRead;
           }
+          if (isChar) writer.write('\"'); // terminate the string
+          writer.write("]\n"); // end of data
         }
-        if (isChar) writer.write('\"'); // terminate the string
-        writer.write(
-            "]\n"
-                + // end of data
-                "    }"
-                + (col < nCols - 1 ? ",\n" : "\n")); // end of variable
+        writer.write("    }" + (col < nCols - 1 ? ",\n" : "\n")); // end of variable
       }
       writer.write(
           "  }\n" + // end of variables object
@@ -285,18 +289,19 @@ public class NcoJsonFiles extends TableWriterFileType {
    * (not write file then transfer file).
    *
    * @param language the index of the selected language
-   * @param ncVersion either NetcdfFileFormat.NETCDF3 or NETCDF4.
    * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'.
    * @param userDapQuery an OPeNDAP DAP-style query string, still percentEncoded (shouldn't be
    *     null). e.g., ATssta[45:1:45][0:1:0][120:10:140][130:10:160]
+   * @param writeValues true if you want the data values to be written.
    * @throws Throwable
    */
-  private void saveAsNcoJson(
+  protected void saveAsNcoJson(
       int language,
       String requestUrl,
       String userDapQuery,
       OutputStreamSource outputStreamSource,
-      EDDGrid grid)
+      EDDGrid grid,
+      boolean writeValues)
       throws Throwable {
     if (EDDGrid.reallyVerbose) String2.log("  EDDGrid.saveAsNc");
 
@@ -376,14 +381,13 @@ public class NcoJsonFiles extends TableWriterFileType {
                   + "      \"type\": \""
                   + tType
                   + "\",\n");
-          writer.write(ada.axisAttributes(avi).toNcoJsonString("      "));
-          writer.write("      \"data\": [");
-          writer.write(ada.axisValues(avi).toJsonCsvString());
-          writer.write(
-              "]\n"
-                  + // end of data
-                  "    }"
-                  + (avi < nRAV - 1 ? ",\n" : "\n")); // end of variable
+          writer.write(ada.axisAttributes(avi).toNcoJsonString("      ", writeValues));
+          if (writeValues) {
+            writer.write("      \"data\": [");
+            writer.write(ada.axisValues(avi).toJsonCsvString());
+            writer.write("]\n"); // end of data
+          }
+          writer.write("    }" + (avi < nRAV - 1 ? ",\n" : "\n")); // end of variable
         }
         writer.write(
             "  }\n" + // end of variables object
@@ -438,6 +442,7 @@ public class NcoJsonFiles extends TableWriterFileType {
           if (dv.destinationDataPAType() == PAType.STRING) {
             int max = 1;
             long n = gda.totalIndex().size();
+            // To provide accurate strlen dimensions, we must load and process all of the data.
             try (DataInputStream dis = gdaa.getDataInputStream(dvi)) {
               for (int i = 0; i < n; i++) max = Math.max(max, dis.readUTF().length());
             }
@@ -484,14 +489,14 @@ public class NcoJsonFiles extends TableWriterFileType {
                 + "      \"type\": \""
                 + tType
                 + "\",\n");
-        writer.write(gda.axisAttributes(avi).toNcoJsonString("      "));
+        writer.write(gda.axisAttributes(avi).toNcoJsonString("      ", writeValues));
 
-        writer.write("      \"data\": [");
-        writer.write(gda.axisValues(avi).toJsonCsvString());
-        writer.write(
-            "]\n"
-                + // end of data
-                "    },\n"); // end of variable
+        if (writeValues) {
+          writer.write("      \"data\": [");
+          writer.write(gda.axisValues(avi).toJsonCsvString());
+          writer.write("]\n"); // end of data
+        }
+        writer.write("    },\n"); // end of variable
       }
 
       // dataVariables
@@ -536,76 +541,79 @@ public class NcoJsonFiles extends TableWriterFileType {
                 + "      \"type\": \""
                 + tType
                 + "\",\n");
-        writer.write(atts.toNcoJsonString("      "));
+        writer.write(atts.toNcoJsonString("      ", writeValues));
 
-        writer.write("      \"data\":\n");
-        for (int avi = 0; avi < nAV; avi++) writer.write("[ ");
-        try (DataInputStream dis = gdaa.getDataInputStream(dvi)) {
+        if (writeValues) {
+          writer.write("      \"data\":\n");
+          for (int avi = 0; avi < nAV; avi++) writer.write("[ ");
+          try (DataInputStream dis = gdaa.getDataInputStream(dvi)) {
 
-          // create the bufferPA
-          PrimitiveArray pa =
-              PrimitiveArray.factory(
-                  dv.destinationDataPAType(), 1, false); // safe since checked above
-          CharArray ca = isChar ? (CharArray) pa : null;
-          if (isChar) writer.write("\""); // start the string
-          tIndex.reset();
-          tIndex.increment(); // so we're at 1st datum
-          for (long nRowsRead = 0; nRowsRead < nRows; nRowsRead++) {
+            // create the bufferPA
+            PrimitiveArray pa =
+                PrimitiveArray.factory(
+                    dv.destinationDataPAType(), 1, false); // safe since checked above
+            CharArray ca = isChar ? (CharArray) pa : null;
+            if (isChar) writer.write("\""); // start the string
+            tIndex.reset();
+            tIndex.increment(); // so we're at 1st datum
+            for (long nRowsRead = 0; nRowsRead < nRows; nRowsRead++) {
 
-            // String2.log(">> preCurrent=" + String2.toCSSVString(preCurrent));
-            pa.clear();
-            pa.readDis(dis, 1);
+              // String2.log(">> preCurrent=" + String2.toCSSVString(preCurrent));
+              pa.clear();
+              pa.readDis(dis, 1);
 
-            // write one data value
-            if (isChar) {
-              // write it as one string with chars concatenated
-              // see "md5_abc" in in http://dust.ess.uci.edu/tmp/in.json.fmt2
-              //  "shape": ["lev"],          //dim lev size=3
-              //  ...
-              //  "data": ["abc"]
-              writer.write(String2.charToJsonString(ca.get(0), 127, true)); // encodeNewline
-            } else if (isString) {
-              // Arrays of Strings are written oddly: (example from
-              // http://dust.ess.uci.edu/tmp/in.json.fmt2)
-              //    "date_rec": {
-              //      "shape": ["time", "char_dmn_lng26"],
-              //      "type": "char",
-              //      "attributes": ...,
-              //      "data": [["2010-11-01T00:00:00.000000"], ["2010-11-01T01:00:00.000000"],
-              // ["2010-11-01T02:00:00.000000"], ["2010-11-01T03:00:00.000000"],
-              // ["2010-11-01T04:00:00.000000"], ["2010-11-01T05:00:00.000000"],
-              // ["2010-11-01T06:00:00.000000"], ["2010-11-01T07:00:00.000000"],
-              // ["2010-11-01T08:00:00.000000"], ["2010-11-01T09:00:00.000000"]]
-              //    },
-              writer.write(
-                  stringOpenBracket + String2.toJson(pa.getString(0)) + stringCloseBracket);
-            } else {
-              writer.write(pa.toJsonCsvString());
-            }
-
-            // write commas and brackets
-            // This was difficult for me: It took me a while to figure out:
-            // Given n (tIndex.nDimensionschanged()),
-            //  the proper separators between data items are
-            //  n-1 close brackets, 1 comma, n-1 open brackets.
-            if (tIndex.increment()) {
-              int nDimChanged = tIndex.nDimensionsChanged();
-              if (nDimChanged == 1) {
-                // easier to deal with this specially
-                if (!isChar) writer.write(", ");
+              // write one data value
+              if (isChar) {
+                // write it as one string with chars concatenated
+                // see "md5_abc" in in http://dust.ess.uci.edu/tmp/in.json.fmt2
+                //  "shape": ["lev"],          //dim lev size=3
+                //  ...
+                //  "data": ["abc"]
+                writer.write(String2.charToJsonString(ca.get(0), 127, true)); // encodeNewline
+              } else if (isString) {
+                // Arrays of Strings are written oddly: (example from
+                // http://dust.ess.uci.edu/tmp/in.json.fmt2)
+                //    "date_rec": {
+                //      "shape": ["time", "char_dmn_lng26"],
+                //      "type": "char",
+                //      "attributes": ...,
+                //      "data": [["2010-11-01T00:00:00.000000"], ["2010-11-01T01:00:00.000000"],
+                // ["2010-11-01T02:00:00.000000"], ["2010-11-01T03:00:00.000000"],
+                // ["2010-11-01T04:00:00.000000"], ["2010-11-01T05:00:00.000000"],
+                // ["2010-11-01T06:00:00.000000"], ["2010-11-01T07:00:00.000000"],
+                // ["2010-11-01T08:00:00.000000"], ["2010-11-01T09:00:00.000000"]]
+                //    },
+                writer.write(
+                    stringOpenBracket + String2.toJson(pa.getString(0)) + stringCloseBracket);
               } else {
-                if (isChar) writer.write('\"'); // close the quote
-                for (int dim = 0; dim < nDimChanged - 1; dim++) writer.write(" ]");
-                writer.write(",\n");
-                for (int dim = 0; dim < nDimChanged - 1; dim++) writer.write("[ ");
-                if (isChar) writer.write('\"'); // open the quote
+                writer.write(pa.toJsonCsvString());
               }
-            } // else it is the end of the data. Handle brackets specially below...
-          } // end of data
+
+              // write commas and brackets
+              // This was difficult for me: It took me a while to figure out:
+              // Given n (tIndex.nDimensionschanged()),
+              //  the proper separators between data items are
+              //  n-1 close brackets, 1 comma, n-1 open brackets.
+              if (tIndex.increment()) {
+                int nDimChanged = tIndex.nDimensionsChanged();
+                if (nDimChanged == 1) {
+                  // easier to deal with this specially
+                  if (!isChar) writer.write(", ");
+                } else {
+                  if (isChar) writer.write('\"'); // close the quote
+                  for (int dim = 0; dim < nDimChanged - 1; dim++) writer.write(" ]");
+                  writer.write(",\n");
+                  for (int dim = 0; dim < nDimChanged - 1; dim++) writer.write("[ ");
+                  if (isChar) writer.write('\"'); // open the quote
+                }
+              } // else it is the end of the data. Handle brackets specially below...
+            } // end of data
+          }
+          if (isChar) writer.write("\""); // start the string
+          for (int avi = 0; avi < nAV; avi++) writer.write(" ]");
+          writer.write("\n"); // end of data
         }
-        if (isChar) writer.write("\""); // start the string
-        for (int avi = 0; avi < nAV; avi++) writer.write(" ]");
-        writer.write("\n" + "    }" + (dvi < nRDV - 1 ? "," : "") + "\n"); // end of variable
+        writer.write("    }" + (dvi < nRDV - 1 ? "," : "") + "\n"); // end of variable
       }
       writer.write(
           "  }\n" + // end of variables object

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/filetypes/NcoJsonHeaderFiles.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/filetypes/NcoJsonHeaderFiles.java
@@ -9,7 +9,7 @@ import gov.noaa.pfel.erddap.util.EDStatic;
     fileTypeExtension = ".json",
     fileTypeName = ".ncoJsonHeader",
     infoUrl = "https://nco.sourceforge.net/nco.html#json",
-    versionAdded = "2.25",
+    versionAdded = "2.31",
     contentType = "application/json",
     addContentDispositionHeader = false)
 public class NcoJsonHeaderFiles extends NcoJsonFiles {

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/filetypes/NcoJsonHeaderFiles.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/filetypes/NcoJsonHeaderFiles.java
@@ -1,0 +1,41 @@
+package gov.noaa.pfel.erddap.filetypes;
+
+import gov.noaa.pfel.erddap.dataset.TableWriter;
+import gov.noaa.pfel.erddap.dataset.TableWriterAllWithMetadata;
+import gov.noaa.pfel.erddap.util.EDMessages.Message;
+import gov.noaa.pfel.erddap.util.EDStatic;
+
+@FileTypeClass(
+    fileTypeExtension = ".json",
+    fileTypeName = ".ncoJsonHeader",
+    infoUrl = "https://nco.sourceforge.net/nco.html#json",
+    versionAdded = "2.25",
+    contentType = "application/json",
+    addContentDispositionHeader = false)
+public class NcoJsonHeaderFiles extends NcoJsonFiles {
+
+  @Override
+  public void writeTableToFileFormat(DapRequestInfo requestInfo, TableWriter tableWriter)
+      throws Throwable {
+    if (tableWriter instanceof TableWriterAllWithMetadata twalwm) {
+      String jsonp = EDStatic.getJsonpFromQuery(requestInfo.language(), requestInfo.userDapQuery());
+      saveAsNcoJson(requestInfo.outputStream(), twalwm, jsonp, false);
+    }
+  }
+
+  @Override
+  public void writeGridToStream(DapRequestInfo requestInfo) throws Throwable {
+    saveAsNcoJson(
+        requestInfo.language(),
+        requestInfo.requestUrl(),
+        requestInfo.userDapQuery(),
+        requestInfo.outputStream(),
+        requestInfo.getEDDGrid(),
+        false);
+  }
+
+  @Override
+  public String getHelpText(int language) {
+    return EDStatic.messages.get(Message.FILE_HELP_NCO_JSON_HEADER, language);
+  }
+}

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/EDMessages.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/EDMessages.java
@@ -556,6 +556,7 @@ public class EDMessages {
     FILE_HELP_NC_CFMA_HEADER,
     FILE_HELP_NCML,
     FILE_HELP_NCO_JSON,
+    FILE_HELP_NCO_JSON_HEADER,
     FILE_HELP_GRID_ODV_TXT,
     FILE_HELP_TABLE_ODV_TXT,
     FILE_HELP_PARQUET,
@@ -2352,6 +2353,9 @@ public class EDMessages {
     translatedMessages.put(
         Message.FILE_HELP_NCO_JSON,
         getNotNothingString(messagesAr, "fileHelp_ncoJson", errorInMethod));
+    translatedMessages.put(
+        Message.FILE_HELP_NCO_JSON_HEADER,
+        getNotNothingString(messagesAr, "fileHelp_ncoJsonHeader", errorInMethod));
     translatedMessages.put(
         Message.FILE_HELP_GRID_ODV_TXT,
         getNotNothingString(messagesAr, "fileHelpGrid_odvTxt", errorInMethod));

--- a/pom.xml
+++ b/pom.xml
@@ -121,8 +121,8 @@
                 <version>3.15.0</version>
                 <configuration>
                     <failOnError>true</failOnError>
-                    <source>25</source>   <!-- java version -->
-                    <target>25</target>
+                    <source>21</source>   <!-- java version -->
+                    <target>21</target>
                     <encoding>UTF-8</encoding>
                     <compilerArgs>
                         <arg>-XDcompilePolicy=simple</arg>

--- a/pom.xml
+++ b/pom.xml
@@ -121,8 +121,8 @@
                 <version>3.15.0</version>
                 <configuration>
                     <failOnError>true</failOnError>
-                    <source>21</source>   <!-- java version -->
-                    <target>21</target>
+                    <source>25</source>   <!-- java version -->
+                    <target>25</target>
                     <encoding>UTF-8</encoding>
                     <compilerArgs>
                         <arg>-XDcompilePolicy=simple</arg>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/messages.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/messages.xml
@@ -3084,6 +3084,7 @@ subsets of scientific datasets in common file formats and make graphs and maps.
 <fileHelp_nc4Header>View the UTF-8 header (the metadata) for the NetCDF-4 .nc file.</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>View the dataset's metadata as the top half of a 7-bit ASCII NCCSV .csv file.</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>Download a UTF-8 NCO lvl=2 JSON file with COARDS/CF/ACDD metadata.</fileHelp_ncoJson>
+<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>Download a NetCDF-3 CF Discrete Sampling Geometries file (Contiguous Ragged Array).</fileHelp_ncCF>
 <fileHelp_ncCFHeader>View the UTF-8 header (the metadata) for the .ncCF file.</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>Download a NetCDF-3 CF Discrete Sampling Geometries file (Multidimensional Array).</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-bn.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-bn.xml
@@ -2532,6 +2532,7 @@ ERDDAP হল একটি ডেটা সার্ভার যা আপন�
 <fileHelp_nc4Header>NetCDF-4 .nc ফাইলের জন্য UTF-8 হেডার (মেটাডেটা) দেখুন।</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>একটি 7-বিট ASCII NCCSV .csv ফাইলের উপরের অর্ধেক হিসাবে ডেটাসেটের মেটাডেটা দেখুন৷</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>COARDS/CF/ACDD মেটাডেটা সহ একটি UTF-8 NCO lvl=2 JSON ফাইল ডাউনলোড করুন৷</fileHelp_ncoJson>
+<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>একটি NetCDF-3 CF ডিসক্রিট স্যাম্পলিং জ্যামিতি ফাইল ডাউনলোড করুন (সংলগ্ন র‌্যাগড অ্যারে)।</fileHelp_ncCF>
 <fileHelp_ncCFHeader>.ncCF ফাইলের জন্য UTF-8 হেডার (মেটাডেটা) দেখুন।</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>একটি NetCDF-3 CF ডিসক্রিট স্যাম্পলিং জ্যামিতি ফাইল ডাউনলোড করুন (মাল্টিডাইমেনশনাল অ্যারে)।</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-bn.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-bn.xml
@@ -2532,7 +2532,8 @@ ERDDAP হল একটি ডেটা সার্ভার যা আপন�
 <fileHelp_nc4Header>NetCDF-4 .nc ফাইলের জন্য UTF-8 হেডার (মেটাডেটা) দেখুন।</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>একটি 7-বিট ASCII NCCSV .csv ফাইলের উপরের অর্ধেক হিসাবে ডেটাসেটের মেটাডেটা দেখুন৷</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>COARDS/CF/ACDD মেটাডেটা সহ একটি UTF-8 NCO lvl=2 JSON ফাইল ডাউনলোড করুন৷</fileHelp_ncoJson>
-<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
+<fileHelp_ncoJsonHeader>একটি মিটা-ডাটা হেডার দেখুনNCOসমাধান:
+</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>একটি NetCDF-3 CF ডিসক্রিট স্যাম্পলিং জ্যামিতি ফাইল ডাউনলোড করুন (সংলগ্ন র‌্যাগড অ্যারে)।</fileHelp_ncCF>
 <fileHelp_ncCFHeader>.ncCF ফাইলের জন্য UTF-8 হেডার (মেটাডেটা) দেখুন।</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>একটি NetCDF-3 CF ডিসক্রিট স্যাম্পলিং জ্যামিতি ফাইল ডাউনলোড করুন (মাল্টিডাইমেনশনাল অ্যারে)।</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-cs.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-cs.xml
@@ -2816,6 +2816,7 @@ Například:
 <fileHelp_nc4Header>Zobrazte záhlaví UTF-8 (metadata) pro soubor NetCDF-4 .nc.</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>Zobrazte metadata datové sady jako horní polovinu 7bitového souboru ASCII NCCSV .csv.</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>Stáhněte si soubor JSON UTF-8 NCO lvl=2 s metadaty COARDS/CF/ACDD.</fileHelp_ncoJson>
+<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>Stáhněte si soubor NetCDF-3 CF Discrete Sampling Geometries (Contiguous Ragged Array).</fileHelp_ncCF>
 <fileHelp_ncCFHeader>Zobrazte záhlaví UTF-8 (metadata) pro soubor .ncCF.</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>Stáhněte si soubor NetCDF-3 CF Discrete Sampling Geometries (Multidimenzionální pole).</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-cs.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-cs.xml
@@ -2816,7 +2816,8 @@ Například:
 <fileHelp_nc4Header>Zobrazte záhlaví UTF-8 (metadata) pro soubor NetCDF-4 .nc.</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>Zobrazte metadata datové sady jako horní polovinu 7bitového souboru ASCII NCCSV .csv.</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>Stáhněte si soubor JSON UTF-8 NCO lvl=2 s metadaty COARDS/CF/ACDD.</fileHelp_ncoJson>
-<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
+<fileHelp_ncoJsonHeader>Zobrazit hlavičku UTF-8 ( metadata) proNCOsoubor lvl=2 JSON.
+</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>Stáhněte si soubor NetCDF-3 CF Discrete Sampling Geometries (Contiguous Ragged Array).</fileHelp_ncCF>
 <fileHelp_ncCFHeader>Zobrazte záhlaví UTF-8 (metadata) pro soubor .ncCF.</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>Stáhněte si soubor NetCDF-3 CF Discrete Sampling Geometries (Multidimenzionální pole).</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-da.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-da.xml
@@ -2811,6 +2811,7 @@ For eksempel:
 <fileHelp_nc4Header>Se UTF-8-headeren (metadataene) for NetCDF-4 .nc-filen.</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>Se datasættets metadata som den øverste halvdel af en 7-bit ASCII NCCSV .csv-fil.</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>Download en UTF-8 NCO lvl=2 JSON-fil med COARDS/CF/ACDD-metadata.</fileHelp_ncoJson>
+<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>Download en NetCDF-3 CF Discrete Sampling Geometries-fil (Contiguous Ragged Array).</fileHelp_ncCF>
 <fileHelp_ncCFHeader>Se UTF-8-headeren (metadataene) for .ncCF-filen.</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>Download en NetCDF-3 CF Discrete Sampling Geometries-fil (Multidimensional Array).</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-da.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-da.xml
@@ -2811,7 +2811,8 @@ For eksempel:
 <fileHelp_nc4Header>Se UTF-8-headeren (metadataene) for NetCDF-4 .nc-filen.</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>Se datasættets metadata som den øverste halvdel af en 7-bit ASCII NCCSV .csv-fil.</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>Download en UTF-8 NCO lvl=2 JSON-fil med COARDS/CF/ACDD-metadata.</fileHelp_ncoJson>
-<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
+<fileHelp_ncoJsonHeader>Se UTF-8-headset (met metadata) for enNCOlvl=2 JSON-fil.
+</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>Download en NetCDF-3 CF Discrete Sampling Geometries-fil (Contiguous Ragged Array).</fileHelp_ncCF>
 <fileHelp_ncCFHeader>Se UTF-8-headeren (metadataene) for .ncCF-filen.</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>Download en NetCDF-3 CF Discrete Sampling Geometries-fil (Multidimensional Array).</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-de.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-de.xml
@@ -2825,7 +2825,8 @@ Zum Beispiel:
 <fileHelp_nc4Header>Zeigen Sie den UTF-8-Header (die Metadaten) für die NetCDF-4 .nc-Datei an.</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>Zeigen Sie die Metadaten des Datasets als obere Hälfte einer 7-Bit-ASCII-NCCSV-CSV-Datei an.</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>Laden Sie eine UTF-8 NCO lvl=2 JSON-Datei mit COARDS/CF/ACDD-Metadaten herunter.</fileHelp_ncoJson>
-<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
+<fileHelp_ncoJsonHeader>Zeige den UTF-8 Header (die Metadaten) für einNCOlvl=2 JSON-Datei.
+</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>Laden Sie eine NetCDF-3 CF Discrete Sampling Geometries-Datei (Contiguous Ragged Array) herunter.</fileHelp_ncCF>
 <fileHelp_ncCFHeader>Zeigen Sie den UTF-8-Header (die Metadaten) für die .ncCF-Datei an.</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>Laden Sie eine NetCDF-3 CF Discrete Sampling Geometries-Datei (Multidimensional Array) herunter.</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-de.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-de.xml
@@ -2825,6 +2825,7 @@ Zum Beispiel:
 <fileHelp_nc4Header>Zeigen Sie den UTF-8-Header (die Metadaten) für die NetCDF-4 .nc-Datei an.</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>Zeigen Sie die Metadaten des Datasets als obere Hälfte einer 7-Bit-ASCII-NCCSV-CSV-Datei an.</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>Laden Sie eine UTF-8 NCO lvl=2 JSON-Datei mit COARDS/CF/ACDD-Metadaten herunter.</fileHelp_ncoJson>
+<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>Laden Sie eine NetCDF-3 CF Discrete Sampling Geometries-Datei (Contiguous Ragged Array) herunter.</fileHelp_ncCF>
 <fileHelp_ncCFHeader>Zeigen Sie den UTF-8-Header (die Metadaten) für die .ncCF-Datei an.</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>Laden Sie eine NetCDF-3 CF Discrete Sampling Geometries-Datei (Multidimensional Array) herunter.</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-el.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-el.xml
@@ -2945,7 +2945,8 @@ ERDDAP είναι ένας διακομιστής δεδομένων που σα
 <fileHelp_nc4Header>Προβάλετε την κεφαλίδα UTF-8 (τα μεταδεδομένα) για το αρχείο NetCDF-4 .nc.</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>Προβάλετε τα μεταδεδομένα του συνόλου δεδομένων ως το επάνω μισό ενός αρχείου ASCII NCCSV .csv 7-bit.</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>Κάντε λήψη ενός αρχείου UTF-8 NCO lvl=2 JSON με μεταδεδομένα COARDS/CF/ACDD.</fileHelp_ncoJson>
-<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
+<fileHelp_ncoJsonHeader>Προβολή της επικεφαλίδας UTF-8 (τα μεταδεδομένα) για έναNCOLvl=2 αρχείο JSON.
+</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>Πραγματοποιήστε λήψη ενός αρχείου NetCDF-3 CF Discrete Sampling Geometries (Contiguous Ragged Array).</fileHelp_ncCF>
 <fileHelp_ncCFHeader>Προβάλετε την κεφαλίδα UTF-8 (τα μεταδεδομένα) για το αρχείο .ncCF.</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>Κάντε λήψη ενός αρχείου NetCDF-3 CF Discrete Sampling Geometries (Πολυδιάστατος Πίνακας).</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-el.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-el.xml
@@ -2945,6 +2945,7 @@ ERDDAP είναι ένας διακομιστής δεδομένων που σα
 <fileHelp_nc4Header>Προβάλετε την κεφαλίδα UTF-8 (τα μεταδεδομένα) για το αρχείο NetCDF-4 .nc.</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>Προβάλετε τα μεταδεδομένα του συνόλου δεδομένων ως το επάνω μισό ενός αρχείου ASCII NCCSV .csv 7-bit.</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>Κάντε λήψη ενός αρχείου UTF-8 NCO lvl=2 JSON με μεταδεδομένα COARDS/CF/ACDD.</fileHelp_ncoJson>
+<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>Πραγματοποιήστε λήψη ενός αρχείου NetCDF-3 CF Discrete Sampling Geometries (Contiguous Ragged Array).</fileHelp_ncCF>
 <fileHelp_ncCFHeader>Προβάλετε την κεφαλίδα UTF-8 (τα μεταδεδομένα) για το αρχείο .ncCF.</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>Κάντε λήψη ενός αρχείου NetCDF-3 CF Discrete Sampling Geometries (Πολυδιάστατος Πίνακας).</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-es.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-es.xml
@@ -3030,7 +3030,8 @@ Por ejemplo:
 <fileHelp_nc4Header>Vea el encabezado UTF-8 (los metadatos) del archivo NetCDF-4 .nc.</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>Vea los metadatos del conjunto de datos como la mitad superior de un archivo .csv ASCII NCCSV de 7 bits.</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>Descargue un archivo JSON UTF-8 NCO lvl=2 con metadatos COARDS/CF/ACDD.</fileHelp_ncoJson>
-<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
+<fileHelp_ncoJsonHeader>Vea el encabezado UTF-8 (los metadatos) para unNCOlvl=2 archivo JSON.
+</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>Descargue un archivo de geometrías de muestreo discretas NetCDF-3 CF (matriz irregular contigua).</fileHelp_ncCF>
 <fileHelp_ncCFHeader>Vea el encabezado UTF-8 (los metadatos) del archivo .ncCF.</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>Descargue un archivo de geometrías de muestreo discretas NetCDF-3 CF (matriz multidimensional).</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-es.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-es.xml
@@ -3030,6 +3030,7 @@ Por ejemplo:
 <fileHelp_nc4Header>Vea el encabezado UTF-8 (los metadatos) del archivo NetCDF-4 .nc.</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>Vea los metadatos del conjunto de datos como la mitad superior de un archivo .csv ASCII NCCSV de 7 bits.</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>Descargue un archivo JSON UTF-8 NCO lvl=2 con metadatos COARDS/CF/ACDD.</fileHelp_ncoJson>
+<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>Descargue un archivo de geometrías de muestreo discretas NetCDF-3 CF (matriz irregular contigua).</fileHelp_ncCF>
 <fileHelp_ncCFHeader>Vea el encabezado UTF-8 (los metadatos) del archivo .ncCF.</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>Descargue un archivo de geometrías de muestreo discretas NetCDF-3 CF (matriz multidimensional).</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-fi.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-fi.xml
@@ -2974,7 +2974,8 @@ Esimerkiksi:
 <fileHelp_nc4Header>Tarkastele NetCDF-4 .nc-tiedoston UTF-8-otsikkoa (metatiedot).</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>Näytä tietojoukon metatiedot 7-bittisen ASCII NCCSV .csv-tiedoston yläosana.</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>Lataa UTF-8 NCO lvl=2 JSON-tiedosto COARDS/CF/ACDD-metatiedoilla.</fileHelp_ncoJson>
-<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
+<fileHelp_ncoJsonHeader>UTF-8-otsikko (metadata)NCOlvl=2 JSON-tiedosto.
+</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>Lataa NetCDF-3 CF Discrete Sampling Geometries -tiedosto (Contiguous Ragged Array).</fileHelp_ncCF>
 <fileHelp_ncCFHeader>Näytä .ncCF-tiedoston UTF-8-otsikko (metatiedot).</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>Lataa NetCDF-3 CF Discrete Sampling Geometries -tiedosto (Multidimensional Array).</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-fi.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-fi.xml
@@ -2974,6 +2974,7 @@ Esimerkiksi:
 <fileHelp_nc4Header>Tarkastele NetCDF-4 .nc-tiedoston UTF-8-otsikkoa (metatiedot).</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>Näytä tietojoukon metatiedot 7-bittisen ASCII NCCSV .csv-tiedoston yläosana.</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>Lataa UTF-8 NCO lvl=2 JSON-tiedosto COARDS/CF/ACDD-metatiedoilla.</fileHelp_ncoJson>
+<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>Lataa NetCDF-3 CF Discrete Sampling Geometries -tiedosto (Contiguous Ragged Array).</fileHelp_ncCF>
 <fileHelp_ncCFHeader>Näytä .ncCF-tiedoston UTF-8-otsikko (metatiedot).</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>Lataa NetCDF-3 CF Discrete Sampling Geometries -tiedosto (Multidimensional Array).</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-fr.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-fr.xml
@@ -2952,6 +2952,7 @@ Par exemple:
 <fileHelp_nc4Header>Affichez l&#39;en-tête UTF-8 (les métadonnées) du fichier NetCDF-4 .nc.</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>Affichez les métadonnées de l&#39;ensemble de données dans la moitié supérieure d&#39;un fichier .csv ASCII NCCSV 7 bits.</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>Téléchargez un fichier JSON UTF-8 NCO lvl=2 avec les métadonnées COARDS/CF/ACDD.</fileHelp_ncoJson>
+<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>Téléchargez un fichier NetCDF-3 CF Discrete Sampling Geometries (Contiguous Ragged Array).</fileHelp_ncCF>
 <fileHelp_ncCFHeader>Affichez l&#39;en-tête UTF-8 (les métadonnées) du fichier .ncCF.</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>Téléchargez un fichier NetCDF-3 CF Discrete Sampling Geometries (Matrice multidimensionnelle).</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-fr.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-fr.xml
@@ -2952,7 +2952,8 @@ Par exemple:
 <fileHelp_nc4Header>Affichez l&#39;en-tête UTF-8 (les métadonnées) du fichier NetCDF-4 .nc.</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>Affichez les métadonnées de l&#39;ensemble de données dans la moitié supérieure d&#39;un fichier .csv ASCII NCCSV 7 bits.</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>Téléchargez un fichier JSON UTF-8 NCO lvl=2 avec les métadonnées COARDS/CF/ACDD.</fileHelp_ncoJson>
-<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
+<fileHelp_ncoJsonHeader>Voir l&#39;en-tête UTF-8 (les métadonnées) pourNCOfichier JSON.
+</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>Téléchargez un fichier NetCDF-3 CF Discrete Sampling Geometries (Contiguous Ragged Array).</fileHelp_ncCF>
 <fileHelp_ncCFHeader>Affichez l&#39;en-tête UTF-8 (les métadonnées) du fichier .ncCF.</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>Téléchargez un fichier NetCDF-3 CF Discrete Sampling Geometries (Matrice multidimensionnelle).</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-ga.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-ga.xml
@@ -2929,6 +2929,7 @@ Mar shampla:
 <fileHelp_nc4Header>Féach ar an gceanntásc UTF-8 (na meiteashonraí) don chomhad NetCDF-4 .nc.</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>Féach ar mheiteashonraí an tacair sonraí mar an leath uachtarach de chomhad 7-giotán ASCII NCCSV .csv.</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>Íoslódáil comhad UTF-8 NCO lvl=2 JSON le meiteashonraí COARDS/CF/ACDD.</fileHelp_ncoJson>
+<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>Íoslódáil comhad Geoiméadracht Samplála Scoite NetCDF-3 CF (Eagar Garbh Tadhlach).</fileHelp_ncCF>
 <fileHelp_ncCFHeader>Féach ar an gceanntásc UTF-8 (na meiteashonraí) don chomhad .ncCF.</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>Íoslódáil comhad Geoiméadracht Samplála Scoite NetCDF-3 CF (Eagar Iltoiseach).</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-ga.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-ga.xml
@@ -2929,7 +2929,8 @@ Mar shampla:
 <fileHelp_nc4Header>Féach ar an gceanntásc UTF-8 (na meiteashonraí) don chomhad NetCDF-4 .nc.</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>Féach ar mheiteashonraí an tacair sonraí mar an leath uachtarach de chomhad 7-giotán ASCII NCCSV .csv.</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>Íoslódáil comhad UTF-8 NCO lvl=2 JSON le meiteashonraí COARDS/CF/ACDD.</fileHelp_ncoJson>
-<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
+<fileHelp_ncoJsonHeader>Féach ar an header UTF-8 (na meiteashonraí) le haghaidhNCOlvl = 2 JSON comhad.
+</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>Íoslódáil comhad Geoiméadracht Samplála Scoite NetCDF-3 CF (Eagar Garbh Tadhlach).</fileHelp_ncCF>
 <fileHelp_ncCFHeader>Féach ar an gceanntásc UTF-8 (na meiteashonraí) don chomhad .ncCF.</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>Íoslódáil comhad Geoiméadracht Samplála Scoite NetCDF-3 CF (Eagar Iltoiseach).</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-gu.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-gu.xml
@@ -2997,6 +2997,7 @@ ERDDAP એ ડેટા સર્વર છે જે તમને સામા�
 <fileHelp_nc4Header>NetCDF-4 .nc ફાઇલ માટે UTF-8 હેડર (મેટાડેટા) જુઓ.</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>ડેટાસેટના મેટાડેટાને 7-બીટ ASCII NCCSV .csv ફાઇલના ટોચના અડધા ભાગ તરીકે જુઓ.</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>COARDS/CF/ACDD મેટાડેટા સાથે UTF-8 NCO lvl=2 JSON ફાઇલ ડાઉનલોડ કરો.</fileHelp_ncoJson>
+<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>નેટસીડીએફ-3 સીએફ ડિસ્ક્રીટ સેમ્પલિંગ જીઓમેટ્રીઝ ફાઇલ ડાઉનલોડ કરો (સંલગ્ન રેગ્ડ એરે).</fileHelp_ncCF>
 <fileHelp_ncCFHeader>.ncCF ફાઇલ માટે UTF-8 હેડર (મેટાડેટા) જુઓ.</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>NetCDF-3 CF ડિસ્ક્રીટ સેમ્પલિંગ જીઓમેટ્રીઝ ફાઈલ ડાઉનલોડ કરો (બહુપરિમાણીય એરે).</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-hi.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-hi.xml
@@ -2629,7 +2629,8 @@ ERDDAP एक डेटा सर्वर है जो आपको साम�
 <fileHelp_nc4Header>NetCDF-4 .nc फ़ाइल के लिए UTF-8 हेडर (मेटाडेटा) देखें।</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>डेटासेट के मेटाडेटा को 7-बिट ASCII NCCSV .csv फ़ाइल के ऊपरी आधे भाग के रूप में देखें।</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>COARDS/CF/ACDD मेटाडेटा के साथ UTF-8 NCO lvl=2 JSON फ़ाइल डाउनलोड करें।</fileHelp_ncoJson>
-<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
+<fileHelp_ncoJsonHeader>एक के लिए UTF-8 हेडर (the मेटाडाटा) देखेंNCOlvl=2 JSON फ़ाइल।
+</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>NetCDF-3 CF डिस्क्रीट सैम्पलिंग जियोमेट्रीज़ फ़ाइल (कंटिग्यूअस रैग्ड ऐरे) डाउनलोड करें।</fileHelp_ncCF>
 <fileHelp_ncCFHeader>.ncCF फ़ाइल के लिए UTF-8 हेडर (मेटाडेटा) देखें।</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>NetCDF-3 CF डिस्क्रीट सैम्पलिंग जियोमेट्रीज़ फ़ाइल (बहुआयामी सारणी) डाउनलोड करें।</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-hi.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-hi.xml
@@ -2629,6 +2629,7 @@ ERDDAP एक डेटा सर्वर है जो आपको साम�
 <fileHelp_nc4Header>NetCDF-4 .nc फ़ाइल के लिए UTF-8 हेडर (मेटाडेटा) देखें।</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>डेटासेट के मेटाडेटा को 7-बिट ASCII NCCSV .csv फ़ाइल के ऊपरी आधे भाग के रूप में देखें।</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>COARDS/CF/ACDD मेटाडेटा के साथ UTF-8 NCO lvl=2 JSON फ़ाइल डाउनलोड करें।</fileHelp_ncoJson>
+<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>NetCDF-3 CF डिस्क्रीट सैम्पलिंग जियोमेट्रीज़ फ़ाइल (कंटिग्यूअस रैग्ड ऐरे) डाउनलोड करें।</fileHelp_ncCF>
 <fileHelp_ncCFHeader>.ncCF फ़ाइल के लिए UTF-8 हेडर (मेटाडेटा) देखें।</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>NetCDF-3 CF डिस्क्रीट सैम्पलिंग जियोमेट्रीज़ फ़ाइल (बहुआयामी सारणी) डाउनलोड करें।</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-hu.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-hu.xml
@@ -3044,7 +3044,8 @@ Például:
 <fileHelp_nc4Header>Tekintse meg a NetCDF-4 .nc fájl UTF-8 fejlécét (a metaadatait).</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>Tekintse meg az adatkészlet metaadatait egy 7 bites ASCII NCCSV .csv fájl felső feleként.</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>Töltsön le egy UTF-8 NCO lvl=2 JSON-fájlt COARDS/CF/ACDD metaadatokkal.</fileHelp_ncoJson>
-<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
+<fileHelp_ncoJsonHeader>Nézd meg az UTF-8 vezetőjét (a metadata) egyNCOlvl=2 JSON fájl.
+</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>Töltsön le egy NetCDF-3 CF Discrete Sampling Geometries fájlt (Contiguous Ragged Array).</fileHelp_ncCF>
 <fileHelp_ncCFHeader>Tekintse meg az .ncCF fájl UTF-8 fejlécét (a metaadatait).</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>Töltsön le egy NetCDF-3 CF Discrete Sampling Geometries fájlt (többdimenziós tömb).</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-hu.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-hu.xml
@@ -3044,6 +3044,7 @@ Például:
 <fileHelp_nc4Header>Tekintse meg a NetCDF-4 .nc fájl UTF-8 fejlécét (a metaadatait).</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>Tekintse meg az adatkészlet metaadatait egy 7 bites ASCII NCCSV .csv fájl felső feleként.</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>Töltsön le egy UTF-8 NCO lvl=2 JSON-fájlt COARDS/CF/ACDD metaadatokkal.</fileHelp_ncoJson>
+<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>Töltsön le egy NetCDF-3 CF Discrete Sampling Geometries fájlt (Contiguous Ragged Array).</fileHelp_ncCF>
 <fileHelp_ncCFHeader>Tekintse meg az .ncCF fájl UTF-8 fejlécét (a metaadatait).</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>Töltsön le egy NetCDF-3 CF Discrete Sampling Geometries fájlt (többdimenziós tömb).</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-id.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-id.xml
@@ -2935,6 +2935,7 @@ Misalnya:
 <fileHelp_nc4Header>Lihat header UTF-8 (metadata) untuk file .nc NetCDF-4.</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>Lihat metadata himpunan data sebagai bagian atas file .csv ASCII NCCSV 7-bit.</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>Unduh file JSON UTF-8 NCO lvl=2 dengan metadata COARDS/CF/ACDD.</fileHelp_ncoJson>
+<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>Unduh file Geometri Pengambilan Sampel Diskrit NetCDF-3 CF (Contiguous Ragged Array).</fileHelp_ncCF>
 <fileHelp_ncCFHeader>Lihat header UTF-8 (metadata) untuk file .ncCF.</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>Unduh file Geometri Pengambilan Sampel Diskrit NetCDF-3 CF (Array Multidimensi).</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-id.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-id.xml
@@ -2935,7 +2935,8 @@ Misalnya:
 <fileHelp_nc4Header>Lihat header UTF-8 (metadata) untuk file .nc NetCDF-4.</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>Lihat metadata himpunan data sebagai bagian atas file .csv ASCII NCCSV 7-bit.</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>Unduh file JSON UTF-8 NCO lvl=2 dengan metadata COARDS/CF/ACDD.</fileHelp_ncoJson>
-<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
+<fileHelp_ncoJsonHeader>Lihat header UTF-8 ( metadata) untuk sebuahNCOlvl=2 file JSON.
+</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>Unduh file Geometri Pengambilan Sampel Diskrit NetCDF-3 CF (Contiguous Ragged Array).</fileHelp_ncCF>
 <fileHelp_ncCFHeader>Lihat header UTF-8 (metadata) untuk file .ncCF.</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>Unduh file Geometri Pengambilan Sampel Diskrit NetCDF-3 CF (Array Multidimensi).</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-it.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-it.xml
@@ -2963,7 +2963,8 @@ Per esempio:
 <fileHelp_nc4Header>Visualizza l&#39;intestazione UTF-8 (i metadati) per il file NetCDF-4 .nc.</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>Visualizza i metadati del set di dati come la metà superiore di un file ASCII NCCSV .csv a 7 bit.</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>Scarica un file JSON UTF-8 NCO lvl=2 con metadati COARDS/CF/ACDD.</fileHelp_ncoJson>
-<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
+<fileHelp_ncoJsonHeader>Visualizza l&#39;intestazione UTF-8 (i metadati) per unNCOlvl=2 file JSON.
+</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>Scaricare un file NetCDF-3 CF Discrete Sampling Geometries (Contiguous Ragged Array).</fileHelp_ncCF>
 <fileHelp_ncCFHeader>Visualizza l&#39;intestazione UTF-8 (i metadati) per il file .ncCF.</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>Scaricare un file NetCDF-3 CF Discrete Sampling Geometries (Multidimensional Array).</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-it.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-it.xml
@@ -2963,6 +2963,7 @@ Per esempio:
 <fileHelp_nc4Header>Visualizza l&#39;intestazione UTF-8 (i metadati) per il file NetCDF-4 .nc.</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>Visualizza i metadati del set di dati come la metà superiore di un file ASCII NCCSV .csv a 7 bit.</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>Scarica un file JSON UTF-8 NCO lvl=2 con metadati COARDS/CF/ACDD.</fileHelp_ncoJson>
+<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>Scaricare un file NetCDF-3 CF Discrete Sampling Geometries (Contiguous Ragged Array).</fileHelp_ncCF>
 <fileHelp_ncCFHeader>Visualizza l&#39;intestazione UTF-8 (i metadati) per il file .ncCF.</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>Scaricare un file NetCDF-3 CF Discrete Sampling Geometries (Multidimensional Array).</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-ja.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-ja.xml
@@ -2615,7 +2615,8 @@ ERDDAPは、科学データセットのサブセットを一般的なファイ�
 <fileHelp_nc4Header>NetCDF-4 .nc ファイルの UTF-8 ヘッダー (メタデータ) を表示します。</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>データセットのメタデータを 7 ビット ASCII NCCSV .csv ファイルの上位半分として表示します。</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>COARDS/CF/ACDD メタデータを含む UTF-8 NCO lvl=2 JSON ファイルをダウンロードします。</fileHelp_ncoJson>
-<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
+<fileHelp_ncoJsonHeader>UTF-8 ヘッダー (メタデータ) をビューNCOlvl=2 JSON ファイル。
+</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>NetCDF-3 CF 離散サンプリング ジオメトリ ファイル (連続不規則配列) をダウンロードします。</fileHelp_ncCF>
 <fileHelp_ncCFHeader>.ncCF ファイルの UTF-8 ヘッダー (メタデータ) を表示します。</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>NetCDF-3 CF 離散サンプリング ジオメトリ ファイル (多次元配列) をダウンロードします。</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-ja.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-ja.xml
@@ -2615,6 +2615,7 @@ ERDDAPは、科学データセットのサブセットを一般的なファイ�
 <fileHelp_nc4Header>NetCDF-4 .nc ファイルの UTF-8 ヘッダー (メタデータ) を表示します。</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>データセットのメタデータを 7 ビット ASCII NCCSV .csv ファイルの上位半分として表示します。</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>COARDS/CF/ACDD メタデータを含む UTF-8 NCO lvl=2 JSON ファイルをダウンロードします。</fileHelp_ncoJson>
+<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>NetCDF-3 CF 離散サンプリング ジオメトリ ファイル (連続不規則配列) をダウンロードします。</fileHelp_ncCF>
 <fileHelp_ncCFHeader>.ncCF ファイルの UTF-8 ヘッダー (メタデータ) を表示します。</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>NetCDF-3 CF 離散サンプリング ジオメトリ ファイル (多次元配列) をダウンロードします。</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-ko.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-ko.xml
@@ -3089,6 +3089,7 @@ ERDDAP 는 일반 파일 형식으로 과학 데이터 세트의 하위 집합�
 <fileHelp_nc4Header>NetCDF-4 .nc 파일의 UTF-8 헤더(메타데이터)를 확인하세요.</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>데이터 세트의 메타데이터를 7비트 ASCII NCCSV .csv 파일의 위쪽 절반으로 봅니다.</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>COARDS/CF/ACDD 메타데이터가 포함된 UTF-8 NCO lvl=2 JSON 파일을 다운로드합니다.</fileHelp_ncoJson>
+<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>NetCDF-3 CF 이산 샘플링 형상 파일(연속 비정형 배열)을 다운로드합니다.</fileHelp_ncCF>
 <fileHelp_ncCFHeader>.ncCF 파일의 UTF-8 헤더(메타데이터)를 확인하세요.</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>NetCDF-3 CF 이산 샘플링 형상 파일(다차원 배열)을 다운로드합니다.</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-ko.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-ko.xml
@@ -3089,7 +3089,8 @@ ERDDAP 는 일반 파일 형식으로 과학 데이터 세트의 하위 집합�
 <fileHelp_nc4Header>NetCDF-4 .nc 파일의 UTF-8 헤더(메타데이터)를 확인하세요.</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>데이터 세트의 메타데이터를 7비트 ASCII NCCSV .csv 파일의 위쪽 절반으로 봅니다.</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>COARDS/CF/ACDD 메타데이터가 포함된 UTF-8 NCO lvl=2 JSON 파일을 다운로드합니다.</fileHelp_ncoJson>
-<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
+<fileHelp_ncoJsonHeader>UTF-8 헤더 보기 (the metadata)NCOlvl=2 JSON 파일.
+</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>NetCDF-3 CF 이산 샘플링 형상 파일(연속 비정형 배열)을 다운로드합니다.</fileHelp_ncCF>
 <fileHelp_ncCFHeader>.ncCF 파일의 UTF-8 헤더(메타데이터)를 확인하세요.</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>NetCDF-3 CF 이산 샘플링 형상 파일(다차원 배열)을 다운로드합니다.</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-mr.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-mr.xml
@@ -3021,6 +3021,7 @@ ERDDAP हा डेटा सर्व्हर आहे जो तुम्�
 <fileHelp_nc4Header>NetCDF-4 .nc फाइलसाठी UTF-8 शीर्षलेख (मेटाडेटा) पहा.</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>डेटासेटचा मेटाडेटा 7-बिट ASCII NCCSV .csv फाईलचा अर्धा भाग म्हणून पहा.</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>COARDS/CF/ACDD मेटाडेटासह UTF-8 NCO lvl=2 JSON फाइल डाउनलोड करा.</fileHelp_ncoJson>
+<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>NetCDF-3 CF डिस्क्रिट सॅम्पलिंग जिओमेट्रीज फाइल डाउनलोड करा (कंटिगुअस रॅग्ड ॲरे).</fileHelp_ncCF>
 <fileHelp_ncCFHeader>.ncCF फाइलसाठी UTF-8 शीर्षलेख (मेटाडेटा) पहा.</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>NetCDF-3 CF डिस्क्रिट सॅम्पलिंग जिओमेट्रीज फाइल डाउनलोड करा (बहुआयामी ॲरे).</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-nl.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-nl.xml
@@ -2964,7 +2964,8 @@ Bijvoorbeeld:
 <fileHelp_nc4Header>Bekijk de UTF-8-header (de metadata) voor het NetCDF-4 .nc-bestand.</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>Bekijk de metagegevens van de dataset als de bovenste helft van een 7-bits ASCII NCCSV .csv-bestand.</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>Download een UTF-8 NCO lvl=2 JSON-bestand met COARDS/CF/ACDD-metagegevens.</fileHelp_ncoJson>
-<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
+<fileHelp_ncoJsonHeader>Bekijk de UTF-8 header (de metagegevens) voor eenNCOlvl=2 JSON-bestand.
+</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>Download een NetCDF-3 CF Discrete Sampling Geometries-bestand (Contiguous Ragged Array).</fileHelp_ncCF>
 <fileHelp_ncCFHeader>Bekijk de UTF-8-header (de metadata) voor het .ncCF-bestand.</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>Download een NetCDF-3 CF Discrete Sampling Geometries-bestand (multidimensionale array).</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-nl.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-nl.xml
@@ -2964,6 +2964,7 @@ Bijvoorbeeld:
 <fileHelp_nc4Header>Bekijk de UTF-8-header (de metadata) voor het NetCDF-4 .nc-bestand.</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>Bekijk de metagegevens van de dataset als de bovenste helft van een 7-bits ASCII NCCSV .csv-bestand.</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>Download een UTF-8 NCO lvl=2 JSON-bestand met COARDS/CF/ACDD-metagegevens.</fileHelp_ncoJson>
+<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>Download een NetCDF-3 CF Discrete Sampling Geometries-bestand (Contiguous Ragged Array).</fileHelp_ncCF>
 <fileHelp_ncCFHeader>Bekijk de UTF-8-header (de metadata) voor het .ncCF-bestand.</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>Download een NetCDF-3 CF Discrete Sampling Geometries-bestand (multidimensionale array).</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-no.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-no.xml
@@ -2964,6 +2964,7 @@ For eksempel:
 <fileHelp_nc4Header>Se UTF-8-overskriften (metadataene) for NetCDF-4 .nc-filen.</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>Se datasettets metadata som den øverste halvdelen av en 7-bits ASCII NCCSV .csv-fil.</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>Last ned en UTF-8 NCO lvl=2 JSON-fil med COARDS/CF/ACDD-metadata.</fileHelp_ncoJson>
+<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>Last ned en NetCDF-3 CF Discrete Sampling Geometries-fil (Contiguous Ragged Array).</fileHelp_ncCF>
 <fileHelp_ncCFHeader>Se UTF-8-overskriften (metadataene) for .ncCF-filen.</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>Last ned en NetCDF-3 CF Discrete Sampling Geometries-fil (Multidimensional Array).</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-no.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-no.xml
@@ -2964,7 +2964,8 @@ For eksempel:
 <fileHelp_nc4Header>Se UTF-8-overskriften (metadataene) for NetCDF-4 .nc-filen.</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>Se datasettets metadata som den øverste halvdelen av en 7-bits ASCII NCCSV .csv-fil.</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>Last ned en UTF-8 NCO lvl=2 JSON-fil med COARDS/CF/ACDD-metadata.</fileHelp_ncoJson>
-<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
+<fileHelp_ncoJsonHeader>Vis UTF-8-hodet (metadata) for enNCOlvl=2 JSON-fil.
+</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>Last ned en NetCDF-3 CF Discrete Sampling Geometries-fil (Contiguous Ragged Array).</fileHelp_ncCF>
 <fileHelp_ncCFHeader>Se UTF-8-overskriften (metadataene) for .ncCF-filen.</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>Last ned en NetCDF-3 CF Discrete Sampling Geometries-fil (Multidimensional Array).</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-pa.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-pa.xml
@@ -2710,6 +2710,7 @@ ERDDAP ਇੱਕ ਡੇਟਾ ਸਰਵਰ ਹੈ ਜੋ ਤੁਹਾਨੂੰ �
 <fileHelp_nc4Header>NetCDF-4 .nc ਫਾਈਲ ਲਈ UTF-8 ਸਿਰਲੇਖ (ਮੈਟਾਡੇਟਾ) ਦੇਖੋ।</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>7-ਬਿੱਟ ASCII NCCSV .csv ਫਾਈਲ ਦੇ ਉੱਪਰਲੇ ਅੱਧ ਦੇ ਰੂਪ ਵਿੱਚ ਡੇਟਾਸੈਟ ਦੇ ਮੈਟਾਡੇਟਾ ਨੂੰ ਵੇਖੋ।</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>COARDS/CF/ACDD ਮੈਟਾਡੇਟਾ ਨਾਲ ਇੱਕ UTF-8 NCO lvl=2 JSON ਫ਼ਾਈਲ ਡਾਊਨਲੋਡ ਕਰੋ।</fileHelp_ncoJson>
+<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>ਇੱਕ NetCDF-3 CF ਡਿਸਕਰੀਟ ਸੈਂਪਲਿੰਗ ਜਿਓਮੈਟਰੀਜ਼ ਫਾਈਲ (ਕੰਟੀਗੁਅਸ ਰੈਗਡ ਐਰੇ) ਡਾਊਨਲੋਡ ਕਰੋ।</fileHelp_ncCF>
 <fileHelp_ncCFHeader>.ncCF ਫਾਈਲ ਲਈ UTF-8 ਸਿਰਲੇਖ (ਮੈਟਾਡੇਟਾ) ਦੇਖੋ।</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>ਇੱਕ NetCDF-3 CF ਡਿਸਕਰੀਟ ਸੈਂਪਲਿੰਗ ਜਿਓਮੈਟਰੀਜ਼ ਫਾਈਲ (ਬਹੁ-ਆਯਾਮੀ ਐਰੇ) ਨੂੰ ਡਾਊਨਲੋਡ ਕਰੋ।</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-pl.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-pl.xml
@@ -2965,6 +2965,7 @@ Na przykład:
 <fileHelp_nc4Header>Wyświetl nagłówek UTF-8 (metadane) pliku NetCDF-4 .nc.</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>Wyświetl metadane zestawu danych jako górną połowę 7-bitowego pliku ASCII NCCSV .csv.</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>Pobierz plik JSON w formacie UTF-8 NCO lvl=2 z metadanymi COARDS/CF/ACDD.</fileHelp_ncoJson>
+<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>Pobierz plik dyskretnych geometrii próbkowania NetCDF-3 CF (ciągła nierówna tablica).</fileHelp_ncCF>
 <fileHelp_ncCFHeader>Wyświetl nagłówek UTF-8 (metadane) pliku .ncCF.</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>Pobierz plik dyskretnych geometrii próbkowania NetCDF-3 CF (tablica wielowymiarowa).</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-pl.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-pl.xml
@@ -2965,7 +2965,8 @@ Na przykład:
 <fileHelp_nc4Header>Wyświetl nagłówek UTF-8 (metadane) pliku NetCDF-4 .nc.</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>Wyświetl metadane zestawu danych jako górną połowę 7-bitowego pliku ASCII NCCSV .csv.</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>Pobierz plik JSON w formacie UTF-8 NCO lvl=2 z metadanymi COARDS/CF/ACDD.</fileHelp_ncoJson>
-<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
+<fileHelp_ncoJsonHeader>Widok nagłówka UTF- 8 (metadane) dlaNCOlvl = 2 plik JSON.
+</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>Pobierz plik dyskretnych geometrii próbkowania NetCDF-3 CF (ciągła nierówna tablica).</fileHelp_ncCF>
 <fileHelp_ncCFHeader>Wyświetl nagłówek UTF-8 (metadane) pliku .ncCF.</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>Pobierz plik dyskretnych geometrii próbkowania NetCDF-3 CF (tablica wielowymiarowa).</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-pt.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-pt.xml
@@ -2803,7 +2803,8 @@ Por exemplo:
 <fileHelp_nc4Header>Visualize o cabeçalho UTF-8 (os metadados) para o arquivo NetCDF-4 .nc.</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>Visualize os metadados do conjunto de dados como a metade superior de um arquivo ASCII NCCSV .csv de 7 bits.</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>Baixe um arquivo UTF-8 NCO lvl = 2 JSON com metadados COARDS / CF / ACDD.</fileHelp_ncoJson>
-<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
+<fileHelp_ncoJsonHeader>Ver o cabeçalho UTF-8 (os metadados) para umNCOlvl=2 arquivo JSON.
+</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>Baixe um arquivo NetCDF-3 CF Discrete Sampling Geometries (Contiguous Ragged Array).</fileHelp_ncCF>
 <fileHelp_ncCFHeader>Visualize o cabeçalho UTF-8 (os metadados) para o arquivo .ncCF.</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>Baixe um arquivo NetCDF-3 CF Discrete Sampling Geometries (Multidimensional Array).</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-pt.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-pt.xml
@@ -2803,6 +2803,7 @@ Por exemplo:
 <fileHelp_nc4Header>Visualize o cabeçalho UTF-8 (os metadados) para o arquivo NetCDF-4 .nc.</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>Visualize os metadados do conjunto de dados como a metade superior de um arquivo ASCII NCCSV .csv de 7 bits.</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>Baixe um arquivo UTF-8 NCO lvl = 2 JSON com metadados COARDS / CF / ACDD.</fileHelp_ncoJson>
+<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>Baixe um arquivo NetCDF-3 CF Discrete Sampling Geometries (Contiguous Ragged Array).</fileHelp_ncCF>
 <fileHelp_ncCFHeader>Visualize o cabeçalho UTF-8 (os metadados) para o arquivo .ncCF.</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>Baixe um arquivo NetCDF-3 CF Discrete Sampling Geometries (Multidimensional Array).</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-ro.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-ro.xml
@@ -2778,7 +2778,8 @@ De exemplu:
 <fileHelp_nc4Header>Vizualizați antetul UTF-8 (metadatele) pentru fișierul NetCDF-4 .nc.</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>Vedeți metadatele setului de date ca jumătatea superioară a unui fișier .csv ASCII NCCSV pe 7 biți.</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>Descărcați un fișier JSON UTF-8 NCO lvl=2 cu metadate COARDS/CF/ACDD.</fileHelp_ncoJson>
-<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
+<fileHelp_ncoJsonHeader>Vizualizați antetul UTF-8 (metadatele) pentru oNCODosarul JSON.
+</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>Descărcați un fișier NetCDF-3 CF Discrete Sampling Geometries (Contiguous Ragged Array).</fileHelp_ncCF>
 <fileHelp_ncCFHeader>Vizualizați antetul UTF-8 (metadatele) pentru fișierul .ncCF.</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>Descărcați un fișier NetCDF-3 CF Discrete Sampling Geometries (Multidimensional Array).</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-ro.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-ro.xml
@@ -2778,6 +2778,7 @@ De exemplu:
 <fileHelp_nc4Header>Vizualizați antetul UTF-8 (metadatele) pentru fișierul NetCDF-4 .nc.</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>Vedeți metadatele setului de date ca jumătatea superioară a unui fișier .csv ASCII NCCSV pe 7 biți.</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>Descărcați un fișier JSON UTF-8 NCO lvl=2 cu metadate COARDS/CF/ACDD.</fileHelp_ncoJson>
+<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>Descărcați un fișier NetCDF-3 CF Discrete Sampling Geometries (Contiguous Ragged Array).</fileHelp_ncCF>
 <fileHelp_ncCFHeader>Vizualizați antetul UTF-8 (metadatele) pentru fișierul .ncCF.</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>Descărcați un fișier NetCDF-3 CF Discrete Sampling Geometries (Multidimensional Array).</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-ru.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-ru.xml
@@ -2877,6 +2877,7 @@ ERDDAP - это сервер данных, который дает вам про
 <fileHelp_nc4Header>Просмотрите заголовок UTF-8 (метаданные) для файла NetCDF-4 .nc.</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>Просматривайте метаданные набора данных как верхнюю половину 7-битного файла ASCII NCCSV .csv.</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>Загрузите файл JSON UTF-8 NCO lvl = 2 с метаданными COARDS / CF / ACDD.</fileHelp_ncoJson>
+<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>Загрузите файл геометрии дискретной выборки NetCDF-3 CF (непрерывный рваный массив).</fileHelp_ncCF>
 <fileHelp_ncCFHeader>Просмотрите заголовок UTF-8 (метаданные) для файла .ncCF.</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>Загрузите файл NetCDF-3 CF Discrete Sampling Geometries (многомерный массив).</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-ru.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-ru.xml
@@ -2877,7 +2877,8 @@ ERDDAP - это сервер данных, который дает вам про
 <fileHelp_nc4Header>Просмотрите заголовок UTF-8 (метаданные) для файла NetCDF-4 .nc.</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>Просматривайте метаданные набора данных как верхнюю половину 7-битного файла ASCII NCCSV .csv.</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>Загрузите файл JSON UTF-8 NCO lvl = 2 с метаданными COARDS / CF / ACDD.</fileHelp_ncoJson>
-<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
+<fileHelp_ncoJsonHeader>Посмотреть заголовок UTF-8 (метаданные)NCOlvl=2 JSON файл.
+</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>Загрузите файл геометрии дискретной выборки NetCDF-3 CF (непрерывный рваный массив).</fileHelp_ncCF>
 <fileHelp_ncCFHeader>Просмотрите заголовок UTF-8 (метаданные) для файла .ncCF.</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>Загрузите файл NetCDF-3 CF Discrete Sampling Geometries (многомерный массив).</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-sv.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-sv.xml
@@ -2791,7 +2791,8 @@ Till exempel:
 <fileHelp_nc4Header>Se UTF-8-huvudet (metadata) för NetCDF-4 .nc-filen.</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>Visa datasetets metadata som den övre halvan av en 7-bitars ASCII NCCSV .csv-fil.</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>Ladda ner en UTF-8 NCO lvl=2 JSON-fil med COARDS/CF/ACDD-metadata.</fileHelp_ncoJson>
-<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
+<fileHelp_ncoJsonHeader>Visa UTF-8-rubriken (metadata) för enNCOlvl=2 JSON-fil.
+</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>Ladda ner en NetCDF-3 CF Discrete Sampling Geometries-fil (Contiguous Ragged Array).</fileHelp_ncCF>
 <fileHelp_ncCFHeader>Se UTF-8-huvudet (metadatan) för .ncCF-filen.</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>Ladda ner en NetCDF-3 CF Discrete Sampling Geometries-fil (Multidimensional Array).</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-sv.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-sv.xml
@@ -2791,6 +2791,7 @@ Till exempel:
 <fileHelp_nc4Header>Se UTF-8-huvudet (metadata) för NetCDF-4 .nc-filen.</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>Visa datasetets metadata som den övre halvan av en 7-bitars ASCII NCCSV .csv-fil.</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>Ladda ner en UTF-8 NCO lvl=2 JSON-fil med COARDS/CF/ACDD-metadata.</fileHelp_ncoJson>
+<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>Ladda ner en NetCDF-3 CF Discrete Sampling Geometries-fil (Contiguous Ragged Array).</fileHelp_ncCF>
 <fileHelp_ncCFHeader>Se UTF-8-huvudet (metadatan) för .ncCF-filen.</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>Ladda ner en NetCDF-3 CF Discrete Sampling Geometries-fil (Multidimensional Array).</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-sw.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-sw.xml
@@ -2756,6 +2756,7 @@ Kwa mfano:
 <fileHelp_nc4Header>Tazama kichwa cha UTF-8 (metadata) ya faili ya NetCDF-4 .nc.</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>Tazama metadata ya seti ya data kama sehemu ya juu ya faili ya 7-bit ASCII NCCSV .csv.</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>Pakua faili ya UTF-8 NCO lvl=2 JSON yenye metadata ya COARDS/CF/ACDD.</fileHelp_ncoJson>
+<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>Pakua faili ya NetCDF-3 CF Discrete Sampling Geometries (Safu ya Ragged Contiguous).</fileHelp_ncCF>
 <fileHelp_ncCFHeader>Tazama kichwa cha UTF-8 (metadata) ya faili ya .ncCF.</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>Pakua faili ya NetCDF-3 CF Discrete Sampling Geometries (Multidimensional Array).</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-th.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-th.xml
@@ -2640,7 +2640,8 @@ ERDDAP เป็นเซิร์ฟเวอร์ข้อมูลที่�
 <fileHelp_nc4Header>ดูส่วนหัว UTF-8 (ข้อมูลเมตา) สำหรับไฟล์ NetCDF-4 .nc</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>ดูข้อมูลเมตาของชุดข้อมูลเป็นครึ่งบนของไฟล์ ASCII NCCSV .csv 7 บิต</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>ดาวน์โหลดไฟล์ UTF-8 NCO lvl=2 JSON พร้อมข้อมูลเมตา COARDS/CF/ACDD</fileHelp_ncoJson>
-<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
+<fileHelp_ncoJsonHeader>แสดงส่วนหัวแบบ UTF- 8 (ข้อมูลกํากับภาพ) สําหรับใช้เป็นNCOVI=2 แฟ้ม Json
+</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>ดาวน์โหลดไฟล์ NetCDF-3 CF Discrete Sampling Geometries (Contiguous Ragged Array)</fileHelp_ncCF>
 <fileHelp_ncCFHeader>ดูส่วนหัว UTF-8 (ข้อมูลเมตา) สำหรับไฟล์ .ncCF</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>ดาวน์โหลดไฟล์ NetCDF-3 CF Discrete Sampling Geometries (อาร์เรย์หลายมิติ)</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-th.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-th.xml
@@ -2640,6 +2640,7 @@ ERDDAP เป็นเซิร์ฟเวอร์ข้อมูลที่�
 <fileHelp_nc4Header>ดูส่วนหัว UTF-8 (ข้อมูลเมตา) สำหรับไฟล์ NetCDF-4 .nc</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>ดูข้อมูลเมตาของชุดข้อมูลเป็นครึ่งบนของไฟล์ ASCII NCCSV .csv 7 บิต</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>ดาวน์โหลดไฟล์ UTF-8 NCO lvl=2 JSON พร้อมข้อมูลเมตา COARDS/CF/ACDD</fileHelp_ncoJson>
+<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>ดาวน์โหลดไฟล์ NetCDF-3 CF Discrete Sampling Geometries (Contiguous Ragged Array)</fileHelp_ncCF>
 <fileHelp_ncCFHeader>ดูส่วนหัว UTF-8 (ข้อมูลเมตา) สำหรับไฟล์ .ncCF</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>ดาวน์โหลดไฟล์ NetCDF-3 CF Discrete Sampling Geometries (อาร์เรย์หลายมิติ)</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-tl.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-tl.xml
@@ -2920,7 +2920,8 @@ Halimbawa:
 <fileHelp_nc4Header>Tingnan ang UTF-8 header (ang metadata) para sa NetCDF-4 .nc file.</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>Tingnan ang metadata ng dataset bilang ang nangungunang kalahati ng isang 7-bit na ASCII NCCSV .csv file.</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>Mag-download ng UTF-8 NCO lvl=2 JSON file na may COARDS/CF/ACDD metadata.</fileHelp_ncoJson>
-<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
+<fileHelp_ncoJsonHeader>Tingnan ang UTF-8 header (ang metadata) para sa isangNCOlvl=2 JSON file.
+</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>Mag-download ng NetCDF-3 CF Discrete Sampling Geometries file (Contiguous Ragged Array).</fileHelp_ncCF>
 <fileHelp_ncCFHeader>Tingnan ang UTF-8 header (ang metadata) para sa .ncCF file.</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>Mag-download ng NetCDF-3 CF Discrete Sampling Geometries file (Multidimensional Array).</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-tl.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-tl.xml
@@ -2920,6 +2920,7 @@ Halimbawa:
 <fileHelp_nc4Header>Tingnan ang UTF-8 header (ang metadata) para sa NetCDF-4 .nc file.</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>Tingnan ang metadata ng dataset bilang ang nangungunang kalahati ng isang 7-bit na ASCII NCCSV .csv file.</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>Mag-download ng UTF-8 NCO lvl=2 JSON file na may COARDS/CF/ACDD metadata.</fileHelp_ncoJson>
+<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>Mag-download ng NetCDF-3 CF Discrete Sampling Geometries file (Contiguous Ragged Array).</fileHelp_ncCF>
 <fileHelp_ncCFHeader>Tingnan ang UTF-8 header (ang metadata) para sa .ncCF file.</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>Mag-download ng NetCDF-3 CF Discrete Sampling Geometries file (Multidimensional Array).</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-tr.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-tr.xml
@@ -2993,6 +2993,7 @@ Uzak bir ERDDAP üzerinde yeni bir özellik kullanmak istiyorsanız, ERDDAP sür
 <fileHelp_nc4Header>NetCDF-4 .nc dosyasının UTF-8 üstbilgisini (meta verileri) görüntüleyin.</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>Veri kümesinin meta verilerini 7 bitlik ASCII NCCSV .csv dosyasının üst yarısı olarak görüntüleyin.</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>COARDS/CF/ACDD meta verilerini içeren bir UTF-8 NCO lvl=2 JSON dosyası indirin.</fileHelp_ncoJson>
+<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>NetCDF-3 CF Ayrık Örnekleme Geometrileri dosyasını (Bitişik Düzensiz Dizi) indirin.</fileHelp_ncCF>
 <fileHelp_ncCFHeader>.ncCF dosyasının UTF-8 üstbilgisini (meta verileri) görüntüleyin.</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>NetCDF-3 CF Ayrık Örnekleme Geometrileri dosyasını (Çok Boyutlu Dizi) indirin.</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-tr.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-tr.xml
@@ -2993,7 +2993,8 @@ Uzak bir ERDDAP üzerinde yeni bir özellik kullanmak istiyorsanız, ERDDAP sür
 <fileHelp_nc4Header>NetCDF-4 .nc dosyasının UTF-8 üstbilgisini (meta verileri) görüntüleyin.</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>Veri kümesinin meta verilerini 7 bitlik ASCII NCCSV .csv dosyasının üst yarısı olarak görüntüleyin.</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>COARDS/CF/ACDD meta verilerini içeren bir UTF-8 NCO lvl=2 JSON dosyası indirin.</fileHelp_ncoJson>
-<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
+<fileHelp_ncoJsonHeader>UTF-8 başlığını ( metadata) bir an içinNCOlvl=2 JSON dosyası.
+</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>NetCDF-3 CF Ayrık Örnekleme Geometrileri dosyasını (Bitişik Düzensiz Dizi) indirin.</fileHelp_ncCF>
 <fileHelp_ncCFHeader>.ncCF dosyasının UTF-8 üstbilgisini (meta verileri) görüntüleyin.</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>NetCDF-3 CF Ayrık Örnekleme Geometrileri dosyasını (Çok Boyutlu Dizi) indirin.</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-uk.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-uk.xml
@@ -2962,7 +2962,8 @@ ERDDAP — це сервер даних, який дає вам простий �
 <fileHelp_nc4Header>Перегляньте заголовок UTF-8 (метадані) для файлу NetCDF-4 .nc.</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>Перегляньте метадані набору даних як верхню половину 7-розрядного файлу ASCII NCCSV .csv.</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>Завантажте файл JSON UTF-8 NCO lvl=2 із метаданими COARDS/CF/ACDD.</fileHelp_ncoJson>
-<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
+<fileHelp_ncoJsonHeader>Перегляд конструктора UTF-8 для метаданихNCOlvl=2 JSON файл.
+</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>Завантажте файл NetCDF-3 CF Geometries Discrete Sampling Geometries (Contiguous Ragged Array).</fileHelp_ncCF>
 <fileHelp_ncCFHeader>Перегляньте заголовок UTF-8 (метадані) для файлу .ncCF.</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>Завантажте файл геометрії дискретної вибірки NetCDF-3 CF (багатовимірний масив).</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-uk.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-uk.xml
@@ -2962,6 +2962,7 @@ ERDDAP — це сервер даних, який дає вам простий �
 <fileHelp_nc4Header>Перегляньте заголовок UTF-8 (метадані) для файлу NetCDF-4 .nc.</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>Перегляньте метадані набору даних як верхню половину 7-розрядного файлу ASCII NCCSV .csv.</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>Завантажте файл JSON UTF-8 NCO lvl=2 із метаданими COARDS/CF/ACDD.</fileHelp_ncoJson>
+<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>Завантажте файл NetCDF-3 CF Geometries Discrete Sampling Geometries (Contiguous Ragged Array).</fileHelp_ncCF>
 <fileHelp_ncCFHeader>Перегляньте заголовок UTF-8 (метадані) для файлу .ncCF.</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>Завантажте файл геометрії дискретної вибірки NetCDF-3 CF (багатовимірний масив).</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-ur.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-ur.xml
@@ -2442,6 +2442,7 @@ ERDDAP ایک ڈیٹا سرور ہے جو آپ کو عام فائل فارمیٹ
 <fileHelp_nc4Header>NetCDF-4 .nc فائل کے لیے UTF-8 ہیڈر (میٹا ڈیٹا) دیکھیں۔</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>ڈیٹاسیٹ کے میٹا ڈیٹا کو 7 بٹ ASCII NCCSV .csv فائل کے اوپری حصے کے طور پر دیکھیں۔</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>COARDS/CF/ACDD میٹا ڈیٹا کے ساتھ UTF-8 NCO lvl=2 JSON فائل ڈاؤن لوڈ کریں۔</fileHelp_ncoJson>
+<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>ایک NetCDF-3 CF ڈسکریٹ سیمپلنگ جیومیٹریز فائل (مسلسل ریگڈ اری) ڈاؤن لوڈ کریں۔</fileHelp_ncCF>
 <fileHelp_ncCFHeader>.ncCF فائل کے لیے UTF-8 ہیڈر (میٹا ڈیٹا) دیکھیں۔</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>ایک NetCDF-3 CF ڈسکریٹ سیمپلنگ جیومیٹریز فائل (کثیر جہتی صف) ڈاؤن لوڈ کریں۔</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-ur.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-ur.xml
@@ -2442,7 +2442,8 @@ ERDDAP ایک ڈیٹا سرور ہے جو آپ کو عام فائل فارمیٹ
 <fileHelp_nc4Header>NetCDF-4 .nc فائل کے لیے UTF-8 ہیڈر (میٹا ڈیٹا) دیکھیں۔</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>ڈیٹاسیٹ کے میٹا ڈیٹا کو 7 بٹ ASCII NCCSV .csv فائل کے اوپری حصے کے طور پر دیکھیں۔</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>COARDS/CF/ACDD میٹا ڈیٹا کے ساتھ UTF-8 NCO lvl=2 JSON فائل ڈاؤن لوڈ کریں۔</fileHelp_ncoJson>
-<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
+<fileHelp_ncoJsonHeader>ایک کے لئے UTF-8 ہیڈ (metadata) دیکھیںNCOLvl=2 JIX فائل.
+</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>ایک NetCDF-3 CF ڈسکریٹ سیمپلنگ جیومیٹریز فائل (مسلسل ریگڈ اری) ڈاؤن لوڈ کریں۔</fileHelp_ncCF>
 <fileHelp_ncCFHeader>.ncCF فائل کے لیے UTF-8 ہیڈر (میٹا ڈیٹا) دیکھیں۔</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>ایک NetCDF-3 CF ڈسکریٹ سیمپلنگ جیومیٹریز فائل (کثیر جہتی صف) ڈاؤن لوڈ کریں۔</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-vi.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-vi.xml
@@ -3047,6 +3047,7 @@ Ví dụ:
 <fileHelp_nc4Header>Xem tiêu đề UTF-8 (siêu dữ liệu) cho tệp NetCDF-4 .nc.</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>Xem siêu dữ liệu của tập dữ liệu dưới dạng nửa trên của tệp .csv ASCII NCCSV 7 bit.</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>Tải xuống tệp JSON UTF-8 NCO lvl=2 có siêu dữ liệu COARDS/CF/ACDD.</fileHelp_ncoJson>
+<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>Tải xuống tệp Hình học lấy mẫu rời rạc NetCDF-3 CF (Mảng rời rạc liền kề).</fileHelp_ncCF>
 <fileHelp_ncCFHeader>Xem tiêu đề UTF-8 (siêu dữ liệu) cho tệp .ncCF.</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>Tải xuống tệp Hình học lấy mẫu rời rạc NetCDF-3 CF (Mảng đa chiều).</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-zh-CN.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-zh-CN.xml
@@ -2438,7 +2438,8 @@ ERDDAP是一个数据服务器，它为您提供一种简单、一致的方式�
 <fileHelp_nc4Header>查看 NetCDF-4 .nc 文件的 UTF-8 标头（元数据）。</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>将数据集的元数据视为 7 位 ASCII NCCSV .csv 文件的上半部分。</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>下载带有 COARDS/CF/ACDD 元数据的 UTF-8 NCO lvl=2 JSON 文件。</fileHelp_ncoJson>
-<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
+<fileHelp_ncoJsonHeader>查看 UTF-8 标题( 元数据) 。NCOlvl=2 JSON文件.
+</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>下载 NetCDF-3 CF 离散采样几何文件（连续不规则阵列）。</fileHelp_ncCF>
 <fileHelp_ncCFHeader>查看 .ncCF 文件的 UTF-8 标头（元数据）。</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>下载 NetCDF-3 CF 离散采样几何文件（多维数组）。</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-zh-CN.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-zh-CN.xml
@@ -2438,6 +2438,7 @@ ERDDAP是一个数据服务器，它为您提供一种简单、一致的方式�
 <fileHelp_nc4Header>查看 NetCDF-4 .nc 文件的 UTF-8 标头（元数据）。</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>将数据集的元数据视为 7 位 ASCII NCCSV .csv 文件的上半部分。</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>下载带有 COARDS/CF/ACDD 元数据的 UTF-8 NCO lvl=2 JSON 文件。</fileHelp_ncoJson>
+<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>下载 NetCDF-3 CF 离散采样几何文件（连续不规则阵列）。</fileHelp_ncCF>
 <fileHelp_ncCFHeader>查看 .ncCF 文件的 UTF-8 标头（元数据）。</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>下载 NetCDF-3 CF 离散采样几何文件（多维数组）。</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-zh-TW.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-zh-TW.xml
@@ -2506,6 +2506,7 @@ ERDDAP是一個資料伺服器，它為您提供了一種簡單、一致的方�
 <fileHelp_nc4Header>查看 NetCDF-4 .nc 檔案的 UTF-8 標頭（元資料）。</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>以 7 位元 ASCII NCCSV .csv 檔案的上半部形式檢視資料集的元資料。</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>下載包含 COARDS/CF/ACDD 元資料的 UTF-8 NCO lvl=2 JSON 檔案。</fileHelp_ncoJson>
+<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>下載 NetCDF-3 CF 離散採樣幾何檔案（連續不規則陣列）。</fileHelp_ncCF>
 <fileHelp_ncCFHeader>查看 .ncCF 檔案的 UTF-8 標頭（元資料）。</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>下載 NetCDF-3 CF 離散採樣幾何檔案（多維數組）。</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-zh-TW.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messages-zh-TW.xml
@@ -2506,7 +2506,8 @@ ERDDAP是一個資料伺服器，它為您提供了一種簡單、一致的方�
 <fileHelp_nc4Header>查看 NetCDF-4 .nc 檔案的 UTF-8 標頭（元資料）。</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>以 7 位元 ASCII NCCSV .csv 檔案的上半部形式檢視資料集的元資料。</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>下載包含 COARDS/CF/ACDD 元資料的 UTF-8 NCO lvl=2 JSON 檔案。</fileHelp_ncoJson>
-<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
+<fileHelp_ncoJsonHeader>檢視 UTF-8 信頭( 中繼資料) 。NCOlvl=2 JSON檔案.
+</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>下載 NetCDF-3 CF 離散採樣幾何檔案（連續不規則陣列）。</fileHelp_ncCF>
 <fileHelp_ncCFHeader>查看 .ncCF 檔案的 UTF-8 標頭（元資料）。</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>下載 NetCDF-3 CF 離散採樣幾何檔案（多維數組）。</fileHelp_ncCFMA>

--- a/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messagesOld.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/translatedMessages/messagesOld.xml
@@ -3084,6 +3084,7 @@ subsets of scientific datasets in common file formats and make graphs and maps.
 <fileHelp_nc4Header>View the UTF-8 header (the metadata) for the NetCDF-4 .nc file.</fileHelp_nc4Header>
 <fileHelp_nccsvMetadata>View the dataset's metadata as the top half of a 7-bit ASCII NCCSV .csv file.</fileHelp_nccsvMetadata>
 <fileHelp_ncoJson>Download a UTF-8 NCO lvl=2 JSON file with COARDS/CF/ACDD metadata.</fileHelp_ncoJson>
+<fileHelp_ncoJsonHeader>View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.</fileHelp_ncoJsonHeader>
 <fileHelp_ncCF>Download a NetCDF-3 CF Discrete Sampling Geometries file (Contiguous Ragged Array).</fileHelp_ncCF>
 <fileHelp_ncCFHeader>View the UTF-8 header (the metadata) for the .ncCF file.</fileHelp_ncCFHeader>
 <fileHelp_ncCFMA>Download a NetCDF-3 CF Discrete Sampling Geometries file (Multidimensional Array).</fileHelp_ncCFMA>

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDGridFromNcFilesTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDGridFromNcFilesTests.java
@@ -2461,8 +2461,8 @@ class EDDGridFromNcFilesTests {
             "            <att name=\"Grib2_Generating_Process_Type\">Forecast</att>\n"
             + "            <att name=\"Grib2_Level_Desc\">Ordered Sequence of Data</att>\n"
             + //// changed in
-              //// netcdf-java
-              //// 4.6.4
+            //// netcdf-java
+            //// 4.6.4
             "            <att name=\"Grib2_Level_Type\" type=\"int\">241</att>\n"
             + // changed in
             // netcdf-java 4.6.4

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDGridFromNcFilesTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDGridFromNcFilesTests.java
@@ -2461,8 +2461,8 @@ class EDDGridFromNcFilesTests {
             "            <att name=\"Grib2_Generating_Process_Type\">Forecast</att>\n"
             + "            <att name=\"Grib2_Level_Desc\">Ordered Sequence of Data</att>\n"
             + //// changed in
-            //// netcdf-java
-            //// 4.6.4
+              //// netcdf-java
+              //// 4.6.4
             "            <att name=\"Grib2_Level_Type\" type=\"int\">241</att>\n"
             + // changed in
             // netcdf-java 4.6.4

--- a/src/test/java/gov/noaa/pfel/erddap/filetypes/NcoJsonHeaderFilesTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/filetypes/NcoJsonHeaderFilesTests.java
@@ -1,0 +1,103 @@
+package gov.noaa.pfel.erddap.filetypes;
+
+import com.cohort.util.File2;
+import com.cohort.util.String2;
+import gov.noaa.pfel.erddap.dataset.EDD;
+import gov.noaa.pfel.erddap.util.EDStatic;
+import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import testDataset.EDDTestDataset;
+import testDataset.Initialization;
+import testSupport.WireMockLifecycle;
+
+public class NcoJsonHeaderFilesTests extends WireMockLifecycle {
+
+  @BeforeAll
+  static void init() {
+    Initialization.edStatic();
+  }
+
+  @Test
+  void testTableNcoJsonHeader() throws Throwable {
+    int language = 0;
+    String tName, results;
+
+    EDD edd = EDDTestDataset.gettestJsonlCSV();
+    tName =
+        edd.makeNewFileForDapQuery(
+            language,
+            null,
+            null,
+            "",
+            EDStatic.config.fullTestCacheDirectory,
+            edd.className(),
+            ".ncoJsonHeader");
+    results = File2.directReadFromUtf8File(EDStatic.config.fullTestCacheDirectory + tName);
+    // String2.log(results);
+
+    // Validate JSON validity
+    JSONObject json = new JSONObject(results);
+
+    // Verify metadata is present
+    com.cohort.util.Test.ensureTrue(json.has("attributes"), "Attributes missing");
+    com.cohort.util.Test.ensureEqual(json.getJSONObject("attributes").getJSONObject("title").getString("data"), "Test of JSON Lines CSV", "Title attribute incorrect");
+
+    // Verify dimensions are present and accurate
+    com.cohort.util.Test.ensureTrue(json.has("dimensions"), "Dimensions missing");
+    com.cohort.util.Test.ensureEqual(json.getJSONObject("dimensions").getInt("row"), 6, "Row dimension incorrect");
+    com.cohort.util.Test.ensureEqual(json.getJSONObject("dimensions").getInt("ship_strlen"), 15, "ship_strlen dimension incorrect");
+
+    // Verify variables are present
+    com.cohort.util.Test.ensureTrue(json.has("variables"), "Variables missing");
+    JSONObject variables = json.getJSONObject("variables");
+    com.cohort.util.Test.ensureTrue(variables.has("ship"), "Variable 'ship' missing");
+
+    // Verify data is NOT present in variables
+    com.cohort.util.Test.ensureTrue(!variables.getJSONObject("ship").has("data"), "Variable 'ship' should not have data");
+    com.cohort.util.Test.ensureTrue(!variables.getJSONObject("time").has("data"), "Variable 'time' should not have data");
+  }
+
+  @Test
+  void testGridNcoJsonHeader() throws Throwable {
+    int language = 0;
+    String tName, results;
+
+    EDD edd = EDDTestDataset.gettestGriddedNcFiles();
+    // Use a simple query that we can easily predict dimensions for
+    // longitude is 0.125 to 359.875, resolution 0.25. 1440 points.
+    // [0:2] is indices 0, 1, 2 -> 3 points.
+    tName =
+        edd.makeNewFileForDapQuery(
+            language,
+            null,
+            null,
+            "y_wind[0][0][0][0:2]",
+            EDStatic.config.fullTestCacheDirectory,
+            edd.className(),
+            ".ncoJsonHeader");
+    results = File2.directReadFromUtf8File(EDStatic.config.fullTestCacheDirectory + tName);
+    // String2.log(results);
+
+    // Validate JSON validity
+    JSONObject json = new JSONObject(results);
+
+    // Verify metadata
+    com.cohort.util.Test.ensureEqual(json.getJSONObject("attributes").getJSONObject("title").getString("data"), "Wind, QuikSCAT, Global, Science Quality (1 Day Composite)", "Title incorrect");
+
+    // Verify dimensions
+    JSONObject dimensions = json.getJSONObject("dimensions");
+    com.cohort.util.Test.ensureEqual(dimensions.getInt("time"), 1, "time dimension incorrect");
+    com.cohort.util.Test.ensureEqual(dimensions.getInt("altitude"), 1, "altitude dimension incorrect");
+    com.cohort.util.Test.ensureEqual(dimensions.getInt("latitude"), 1, "latitude dimension incorrect");
+    com.cohort.util.Test.ensureEqual(dimensions.getInt("longitude"), 3, "longitude dimension incorrect");
+
+    // Verify variables
+    JSONObject variables = json.getJSONObject("variables");
+    com.cohort.util.Test.ensureTrue(variables.has("y_wind"), "Variable 'y_wind' missing");
+
+    // Verify no data for variables
+    com.cohort.util.Test.ensureTrue(!variables.getJSONObject("y_wind").has("data"), "Variable 'y_wind' should not have data");
+    com.cohort.util.Test.ensureTrue(!variables.getJSONObject("latitude").has("data"), "Variable 'latitude' should not have data");
+  }
+}

--- a/src/test/java/gov/noaa/pfel/erddap/filetypes/NcoJsonHeaderFilesTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/filetypes/NcoJsonHeaderFilesTests.java
@@ -1,7 +1,6 @@
 package gov.noaa.pfel.erddap.filetypes;
 
 import com.cohort.util.File2;
-import com.cohort.util.String2;
 import gov.noaa.pfel.erddap.dataset.EDD;
 import gov.noaa.pfel.erddap.util.EDStatic;
 import org.json.JSONObject;
@@ -41,12 +40,19 @@ public class NcoJsonHeaderFilesTests extends WireMockLifecycle {
 
     // Verify metadata is present
     com.cohort.util.Test.ensureTrue(json.has("attributes"), "Attributes missing");
-    com.cohort.util.Test.ensureEqual(json.getJSONObject("attributes").getJSONObject("title").getString("data"), "Test of JSON Lines CSV", "Title attribute incorrect");
+    com.cohort.util.Test.ensureEqual(
+        json.getJSONObject("attributes").getJSONObject("title").getString("data"),
+        "Test of JSON Lines CSV",
+        "Title attribute incorrect");
 
     // Verify dimensions are present and accurate
     com.cohort.util.Test.ensureTrue(json.has("dimensions"), "Dimensions missing");
-    com.cohort.util.Test.ensureEqual(json.getJSONObject("dimensions").getInt("row"), 6, "Row dimension incorrect");
-    com.cohort.util.Test.ensureEqual(json.getJSONObject("dimensions").getInt("ship_strlen"), 15, "ship_strlen dimension incorrect");
+    com.cohort.util.Test.ensureEqual(
+        json.getJSONObject("dimensions").getInt("row"), 6, "Row dimension incorrect");
+    com.cohort.util.Test.ensureEqual(
+        json.getJSONObject("dimensions").getInt("ship_strlen"),
+        15,
+        "ship_strlen dimension incorrect");
 
     // Verify variables are present
     com.cohort.util.Test.ensureTrue(json.has("variables"), "Variables missing");
@@ -54,8 +60,10 @@ public class NcoJsonHeaderFilesTests extends WireMockLifecycle {
     com.cohort.util.Test.ensureTrue(variables.has("ship"), "Variable 'ship' missing");
 
     // Verify data is NOT present in variables
-    com.cohort.util.Test.ensureTrue(!variables.getJSONObject("ship").has("data"), "Variable 'ship' should not have data");
-    com.cohort.util.Test.ensureTrue(!variables.getJSONObject("time").has("data"), "Variable 'time' should not have data");
+    com.cohort.util.Test.ensureTrue(
+        !variables.getJSONObject("ship").has("data"), "Variable 'ship' should not have data");
+    com.cohort.util.Test.ensureTrue(
+        !variables.getJSONObject("time").has("data"), "Variable 'time' should not have data");
   }
 
   @Test
@@ -83,21 +91,30 @@ public class NcoJsonHeaderFilesTests extends WireMockLifecycle {
     JSONObject json = new JSONObject(results);
 
     // Verify metadata
-    com.cohort.util.Test.ensureEqual(json.getJSONObject("attributes").getJSONObject("title").getString("data"), "Wind, QuikSCAT, Global, Science Quality (1 Day Composite)", "Title incorrect");
+    com.cohort.util.Test.ensureEqual(
+        json.getJSONObject("attributes").getJSONObject("title").getString("data"),
+        "Wind, QuikSCAT, Global, Science Quality (1 Day Composite)",
+        "Title incorrect");
 
     // Verify dimensions
     JSONObject dimensions = json.getJSONObject("dimensions");
     com.cohort.util.Test.ensureEqual(dimensions.getInt("time"), 1, "time dimension incorrect");
-    com.cohort.util.Test.ensureEqual(dimensions.getInt("altitude"), 1, "altitude dimension incorrect");
-    com.cohort.util.Test.ensureEqual(dimensions.getInt("latitude"), 1, "latitude dimension incorrect");
-    com.cohort.util.Test.ensureEqual(dimensions.getInt("longitude"), 3, "longitude dimension incorrect");
+    com.cohort.util.Test.ensureEqual(
+        dimensions.getInt("altitude"), 1, "altitude dimension incorrect");
+    com.cohort.util.Test.ensureEqual(
+        dimensions.getInt("latitude"), 1, "latitude dimension incorrect");
+    com.cohort.util.Test.ensureEqual(
+        dimensions.getInt("longitude"), 3, "longitude dimension incorrect");
 
     // Verify variables
     JSONObject variables = json.getJSONObject("variables");
     com.cohort.util.Test.ensureTrue(variables.has("y_wind"), "Variable 'y_wind' missing");
 
     // Verify no data for variables
-    com.cohort.util.Test.ensureTrue(!variables.getJSONObject("y_wind").has("data"), "Variable 'y_wind' should not have data");
-    com.cohort.util.Test.ensureTrue(!variables.getJSONObject("latitude").has("data"), "Variable 'latitude' should not have data");
+    com.cohort.util.Test.ensureTrue(
+        !variables.getJSONObject("y_wind").has("data"), "Variable 'y_wind' should not have data");
+    com.cohort.util.Test.ensureTrue(
+        !variables.getJSONObject("latitude").has("data"),
+        "Variable 'latitude' should not have data");
   }
 }

--- a/src/test/java/jetty/JettyTests.java
+++ b/src/test/java/jetty/JettyTests.java
@@ -6266,6 +6266,7 @@ class JettyTests extends WireMockLifecycle {
 <option>.nccsv - Download a NetCDF-3-like 7-bit ASCII NCCSV .csv file with COARDS/CF/ACDD metadata.
 <option>.nccsvMetadata - View the dataset&#39;s metadata as the top half of a 7-bit ASCII NCCSV .csv file.
 <option>.ncoJson - Download a UTF-8 NCO lvl=2 JSON file with COARDS/CF/ACDD metadata.
+<option>.ncoJsonHeader - View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.
 <option>.odvTxt - Download longitude,latitude,time,otherColumns as an ISO-8859-1 ODV Generic Spreadsheet File (.txt).
 <option>.parquet - Download as a parquet file. Metadata contains column names (&quot;column_names&quot;) and units (&quot;column_units&quot;).
 <option>.parquetWMeta - Download as a parquet file with detailed metadata.
@@ -6282,7 +6283,8 @@ class JettyTests extends WireMockLifecycle {
 <option>.smallPdf - View a small .pdf image file with a graph or map.
 <option>.smallPng - View a small .png image file with a graph or map.
 <option>.transparentPng - View a .png image file (just the data, without axes, landmask, or legend).
-            """));
+            """),
+        "results=\n" + results);
 
     results =
         SSR.getUrlResponseStringUnchanged(EDStatic.erddapUrl + "/griddap/testGriddedNcFiles.html");
@@ -6316,6 +6318,7 @@ class JettyTests extends WireMockLifecycle {
 <option>.nccsvMetadata - View the dataset&#39;s metadata as the top half of a 7-bit ASCII NCCSV .csv file.
 <option>.ncml - View the dataset&#39;s structure and metadata as a UTF-8 NCML .xml file.
 <option>.ncoJson - Download a UTF-8 NCO lvl=2 JSON file with COARDS/CF/ACDD metadata.
+<option>.ncoJsonHeader - View the UTF-8 header (the metadata) for an NCO lvl=2 JSON file.
 <option>.odvTxt - Download time,latitude,longitude,otherVariables as an ODV Generic Spreadsheet File (.txt).
 <option>.parquet - Download as a parquet file. Metadata contains column names (&quot;column_names&quot;) and units (&quot;column_units&quot;).
 <option>.parquetWMeta - Download as a parquet file with detailed metadata.
@@ -6334,7 +6337,8 @@ class JettyTests extends WireMockLifecycle {
 <option>.smallPdf - View a small .pdf image file with a graph or map.
 <option>.smallPng - View a small .png image file with a graph or map.
 <option>.transparentPng - View a .png image file (just the data, without axes, landmask, or legend).
-            """));
+            """),
+        "results=\n" + results);
   }
 
   /**


### PR DESCRIPTION
This change adds a new output format `.ncoJsonHeader` to ERDDAP. This format provides the metadata and structure (header) of a dataset in NCO-style JSON (lvl=2) without including the actual data values. It supports both tabular and gridded datasets. The implementation shares logic with the existing `.ncoJson` format but omits the data block. Accurate string length dimensions are preserved by performing a full data scan. The generated JSON is validated to be compliant with the JSON specification by avoiding dangling commas.

---
*PR created automatically by Jules for task [598500945942390129](https://jules.google.com/task/598500945942390129) started by @ChrisJohnNOAA*