### PR TITLE
Mock external dependencies in JettyTests

### DIFF
--- a/src/test/java/jetty/JettyTests.java
+++ b/src/test/java/jetty/JettyTests.java
@@ -17679,23 +17679,22 @@ netcdf EDDTableFromNcFiles_Data.nc {
     DConnect dConnect;
     DDS dds;
 
-    /*
-     * //test of Sequence DAP dataset
-     * String2.log("\n*** test of Sequence DAP dataset");
-     * String sequenceUrl =
-     * "https://coastwatch.pfeg.noaa.gov/erddap/tabledap/erdGlobecMoc1";
-     * dConnect = new DConnect(sequenceUrl, true, 1, 1);
-     * dds = dConnect.getDDS(DEFAULT_TIMEOUT);
-     * results = String2.toCSSVString(findVarsWithSharedDimensions(dds));
-     * expected =
-     * "zztop";
-     * Test.ensureEqual(results, expected, "results=" + results);
-     */
+    // test of Sequence DAP dataset
+    String2.log("\n*** test of Sequence DAP dataset");
+    String sequenceUrl =
+        System.getProperty("test.coastwatch.pfegUrl", "https://coastwatch.pfeg.noaa.gov")
+            + "/erddap/tabledap/erdGlobecMoc1";
+    dConnect = new DConnect(sequenceUrl, true, 1, 1);
+    dds = dConnect.getDDS(OpendapHelper.DEFAULT_TIMEOUT);
+    results = String2.toCSSVString(OpendapHelper.findVarsWithSharedDimensions(dds));
+    expected = "";
+    Test.ensureEqual(results, expected, "results=" + results);
 
     // test of DArray DAP dataset
     // 2018-09-13 https: works in browser by not yet in Java
     String dArrayUrl =
-        "https://tds.coaps.fsu.edu/thredds/dodsC/samos/data/research/WTEP/2012/WTEP_20120128v30001.nc";
+        System.getProperty("test.coaps.fsuUrl", "https://tds.coaps.fsu.edu")
+            + "/thredds/dodsC/samos/data/research/WTEP/2012/WTEP_20120128v30001.nc";
     String2.log("\n*** test of DArray DAP dataset\n" + dArrayUrl);
     dConnect = new DConnect(dArrayUrl, true, 1, 1);
     dds = dConnect.getDDS(OpendapHelper.DEFAULT_TIMEOUT);

--- a/src/test/java/testSupport/WireMockStarter.java
+++ b/src/test/java/testSupport/WireMockStarter.java
@@ -22,6 +22,8 @@ public class WireMockStarter {
 
     // Set system property so tests will use the mock base URL when they build URLs
     System.setProperty("test.apdrc.hawaiiUrl", "http://localhost:" + port());
+    System.setProperty("test.coaps.fsuUrl", "http://localhost:" + port());
+    System.setProperty("test.coastwatch.pfegUrl", "http://localhost:" + port());
 
     // Stub basic SODA responses from resources/mock/apdrc/
     stubFromResourceDap(
@@ -148,6 +150,11 @@ public class WireMockStarter {
     WireMock.stubFor(
         WireMock.get(WireMock.urlEqualTo("/dods/public_data/SODA/soda_pop2.2.4"))
             .willReturn(WireMock.aResponse().withStatus(200).withBody("APDRC SODA mock root")));
+
+    stubFromResourceDap(
+        "/thredds/dodsC/samos/data/research/WTEP/2012/WTEP_20120128v30001.nc.dds",
+        "/mock/coaps/WTEP_20120128v30001.nc.dds");
+    stubFromResourceDap("/erddap/tabledap/erdGlobecMoc1.dds", "/mock/coastwatch/erdGlobecMoc1.dds");
   }
 
   private static void stubFromResource(String urlPath, String resourcePath) {

--- a/src/test/resources/mock/coaps/WTEP_20120128v30001.nc.dds
+++ b/src/test/resources/mock/coaps/WTEP_20120128v30001.nc.dds
@@ -1,0 +1,19 @@
+Dataset {
+    Int32 time[time = 144];
+    Float32 lat[time = 144];
+    Float32 lon[time = 144];
+    Float32 PL_HD[time = 144];
+    Float32 PL_CRS[time = 144];
+    Float32 DIR[time = 144];
+    Float32 PL_WDIR[time = 144];
+    Float32 PL_SPD[time = 144];
+    Float32 SPD[time = 144];
+    Float32 PL_WSPD[time = 144];
+    Float32 P[time = 144];
+    Float32 T[time = 144];
+    Float32 RH[time = 144];
+    Int32 date[time = 144];
+    Int32 time_of_day[time = 144];
+    String flag[time = 144];
+    String history[h_num = 50];
+} samos/data/research/WTEP/2012/WTEP_20120128v30001.nc;

--- a/src/test/resources/mock/coastwatch/erdGlobecMoc1.dds
+++ b/src/test/resources/mock/coastwatch/erdGlobecMoc1.dds
@@ -1,0 +1,27 @@
+Dataset {
+  Sequence {
+    String cruise_id;
+    Float32 longitude;
+    Float32 latitude;
+    Float64 time;
+    Byte cast_no;
+    String station_id;
+    Float32 abund_m3;
+    String comments;
+    String counter_id;
+    String d_n_flag;
+    Byte gear_area_m2;
+    Float32 gear_mesh;
+    String gear_type;
+    String genus_species;
+    String life_stage;
+    String local_code;
+    Float32 max_sample_depth;
+    Float32 min_sample_depth;
+    String nodc_code;
+    String program;
+    Byte sample_id;
+    Float32 vol_filt;
+    Int16 water_depth;
+  } s;
+} s;


### PR DESCRIPTION
I have addressed the flakiness in `JettyTests.testFindVarsWithSharedDimensions` by mocking the external datasets it depends on.

Key improvements:
1. **Reliability**: The test no longer depends on the availability of `tds.coaps.fsu.edu` or `coastwatch.pfeg.noaa.gov`. It now uses local WireMock stubs.
2. **Coverage**: I have re-enabled and fixed the commented-out test case for the Coastwatch Sequence dataset.
3. **Consistency**: The solution follows the project's existing mocking patterns using `WireMockStarter` and system properties.

I verified the changes by creating a temporary test class that initializes `EDStatic` and runs the mocked logic, as the full `JettyTests` suite has a very long setup time and strict group exclusions. The mocked calls were confirmed to return the expected values.

---
*PR created automatically by Jules for task [2260271446735327846](https://jules.google.com/task/2260271446735327846) started by @ChrisJohnNOAA*