### PR TITLE
Implement Bulk FileChannel Writing in PrimitiveArray and Refactor Column Writers

### DIFF
--- a/WEB-INF/classes/com/cohort/array/ByteArray.java
+++ b/WEB-INF/classes/com/cohort/array/ByteArray.java
@@ -1451,6 +1451,25 @@ public class ByteArray extends PrimitiveArray {
    * @throws Exception if trouble
    */
   @Override
+  public long writeToChannel(java.nio.channels.FileChannel channel) throws java.io.IOException {
+    return writeToChannel(channel, java.nio.ByteOrder.nativeOrder());
+  }
+
+  @Override
+  public long writeToChannel(java.nio.channels.FileChannel channel, java.nio.ByteOrder byteOrder)
+      throws java.io.IOException {
+    if (size == 0) {
+      return 0L;
+    }
+    long byteCount = (long) size * elementSize();
+    java.nio.ByteBuffer buffer = array.asSlice(0, byteCount).asByteBuffer();
+    while (buffer.hasRemaining()) {
+      channel.write(buffer);
+    }
+    return byteCount;
+  }
+
+  @Override
   public int writeDos(final DataOutputStream dos) throws Exception {
     dos.write(toArray(), 0, size); // special case
     return size == 0 ? 0 : 1;

--- a/WEB-INF/classes/com/cohort/array/CharArray.java
+++ b/WEB-INF/classes/com/cohort/array/CharArray.java
@@ -1409,19 +1409,12 @@ public class CharArray extends PrimitiveArray {
     int elemSize = elementSize();
     boolean swap = (byteOrder != java.nio.ByteOrder.nativeOrder());
 
-    if (!swap) {
-      java.nio.ByteBuffer buffer = null;
-      try {
-        buffer = array.asSlice(0, byteCount).asByteBuffer();
-      } catch (UnsupportedOperationException e) {
-        // Fallback for heap segments backed by non-byte arrays
+    if (!swap && wrappedArray == null) {
+      java.nio.ByteBuffer buffer = array.asSlice(0, byteCount).asByteBuffer();
+      while (buffer.hasRemaining()) {
+        channel.write(buffer);
       }
-      if (buffer != null) {
-        while (buffer.hasRemaining()) {
-          channel.write(buffer);
-        }
-        return byteCount;
-      }
+      return byteCount;
     }
 
     PrimitiveArray.ScratchBuffer scratch = PrimitiveArray.SCRATCH_BUFFER.get();

--- a/WEB-INF/classes/com/cohort/array/CharArray.java
+++ b/WEB-INF/classes/com/cohort/array/CharArray.java
@@ -1407,12 +1407,10 @@ public class CharArray extends PrimitiveArray {
     }
     long byteCount = (long) size * elementSize();
     int elemSize = elementSize();
-    int chunkCapacity = (int) Math.min(byteCount, 65536);
-    chunkCapacity = (chunkCapacity / elemSize) * elemSize;
-    byte[] chunkBytes = new byte[chunkCapacity];
-    java.lang.foreign.MemorySegment chunkSegment =
-        java.lang.foreign.MemorySegment.ofArray(chunkBytes);
-    java.nio.ByteBuffer tempBuffer = java.nio.ByteBuffer.wrap(chunkBytes);
+    PrimitiveArray.ScratchBuffer scratch = PrimitiveArray.SCRATCH_BUFFER.get();
+    int chunkCapacity = scratch.bytes.length;
+    java.lang.foreign.MemorySegment chunkSegment = scratch.segment;
+    java.nio.ByteBuffer tempBuffer = scratch.buffer;
 
     boolean swap = (byteOrder != java.nio.ByteOrder.nativeOrder());
     int offset = 0;

--- a/WEB-INF/classes/com/cohort/array/CharArray.java
+++ b/WEB-INF/classes/com/cohort/array/CharArray.java
@@ -1407,12 +1407,28 @@ public class CharArray extends PrimitiveArray {
     }
     long byteCount = (long) size * elementSize();
     int elemSize = elementSize();
+    boolean swap = (byteOrder != java.nio.ByteOrder.nativeOrder());
+
+    if (!swap) {
+      java.nio.ByteBuffer buffer = null;
+      try {
+        buffer = array.asSlice(0, byteCount).asByteBuffer();
+      } catch (UnsupportedOperationException e) {
+        // Fallback for heap segments backed by non-byte arrays
+      }
+      if (buffer != null) {
+        while (buffer.hasRemaining()) {
+          channel.write(buffer);
+        }
+        return byteCount;
+      }
+    }
+
     PrimitiveArray.ScratchBuffer scratch = PrimitiveArray.SCRATCH_BUFFER.get();
     int chunkCapacity = scratch.bytes.length;
     java.lang.foreign.MemorySegment chunkSegment = scratch.segment;
     java.nio.ByteBuffer tempBuffer = scratch.buffer;
 
-    boolean swap = (byteOrder != java.nio.ByteOrder.nativeOrder());
     int offset = 0;
     while (offset < byteCount) {
       int len = (int) Math.min(byteCount - offset, chunkCapacity);

--- a/WEB-INF/classes/com/cohort/array/CharArray.java
+++ b/WEB-INF/classes/com/cohort/array/CharArray.java
@@ -1395,6 +1395,52 @@ public class CharArray extends PrimitiveArray {
    * @throws Exception if trouble
    */
   @Override
+  public long writeToChannel(java.nio.channels.FileChannel channel) throws java.io.IOException {
+    return writeToChannel(channel, java.nio.ByteOrder.nativeOrder());
+  }
+
+  @Override
+  public long writeToChannel(java.nio.channels.FileChannel channel, java.nio.ByteOrder byteOrder)
+      throws java.io.IOException {
+    if (size == 0) {
+      return 0L;
+    }
+    long byteCount = (long) size * elementSize();
+    int elemSize = elementSize();
+    int chunkCapacity = (int) Math.min(byteCount, 65536);
+    chunkCapacity = (chunkCapacity / elemSize) * elemSize;
+    byte[] chunkBytes = new byte[chunkCapacity];
+    java.lang.foreign.MemorySegment chunkSegment =
+        java.lang.foreign.MemorySegment.ofArray(chunkBytes);
+    java.nio.ByteBuffer tempBuffer = java.nio.ByteBuffer.wrap(chunkBytes);
+
+    boolean swap = (byteOrder != java.nio.ByteOrder.nativeOrder());
+    int offset = 0;
+    while (offset < byteCount) {
+      int len = (int) Math.min(byteCount - offset, chunkCapacity);
+      int numElems = len / elemSize;
+
+      java.lang.foreign.MemorySegment.copy(array, offset, chunkSegment, 0, len);
+
+      tempBuffer.clear();
+      tempBuffer.limit(len);
+
+      if (swap) {
+        java.nio.ShortBuffer view = tempBuffer.asShortBuffer();
+        for (int i = 0; i < numElems; i++) {
+          view.put(i, Short.reverseBytes(view.get(i)));
+        }
+      }
+
+      while (tempBuffer.hasRemaining()) {
+        channel.write(tempBuffer);
+      }
+      offset += len;
+    }
+    return byteCount;
+  }
+
+  @Override
   public int writeDos(DataOutputStream dos) throws Exception {
     for (int i = 0; i < size; i++) dos.writeChar(getArrayVal(i));
     return size == 0 ? 0 : 2;

--- a/WEB-INF/classes/com/cohort/array/DoubleArray.java
+++ b/WEB-INF/classes/com/cohort/array/DoubleArray.java
@@ -1185,6 +1185,52 @@ public class DoubleArray extends PrimitiveArray {
    * @throws Exception if trouble
    */
   @Override
+  public long writeToChannel(java.nio.channels.FileChannel channel) throws java.io.IOException {
+    return writeToChannel(channel, java.nio.ByteOrder.nativeOrder());
+  }
+
+  @Override
+  public long writeToChannel(java.nio.channels.FileChannel channel, java.nio.ByteOrder byteOrder)
+      throws java.io.IOException {
+    if (size == 0) {
+      return 0L;
+    }
+    long byteCount = (long) size * elementSize();
+    int elemSize = elementSize();
+    int chunkCapacity = (int) Math.min(byteCount, 65536);
+    chunkCapacity = (chunkCapacity / elemSize) * elemSize;
+    byte[] chunkBytes = new byte[chunkCapacity];
+    java.lang.foreign.MemorySegment chunkSegment =
+        java.lang.foreign.MemorySegment.ofArray(chunkBytes);
+    java.nio.ByteBuffer tempBuffer = java.nio.ByteBuffer.wrap(chunkBytes);
+
+    boolean swap = (byteOrder != java.nio.ByteOrder.nativeOrder());
+    int offset = 0;
+    while (offset < byteCount) {
+      int len = (int) Math.min(byteCount - offset, chunkCapacity);
+      int numElems = len / elemSize;
+
+      java.lang.foreign.MemorySegment.copy(array, offset, chunkSegment, 0, len);
+
+      tempBuffer.clear();
+      tempBuffer.limit(len);
+
+      if (swap) {
+        java.nio.LongBuffer view = tempBuffer.asLongBuffer();
+        for (int i = 0; i < numElems; i++) {
+          view.put(i, Long.reverseBytes(view.get(i)));
+        }
+      }
+
+      while (tempBuffer.hasRemaining()) {
+        channel.write(tempBuffer);
+      }
+      offset += len;
+    }
+    return byteCount;
+  }
+
+  @Override
   public int writeDos(final DataOutputStream dos) throws Exception {
     for (int i = 0; i < size; i++) dos.writeDouble(getArrayVal(i));
     return size == 0 ? 0 : 8;

--- a/WEB-INF/classes/com/cohort/array/DoubleArray.java
+++ b/WEB-INF/classes/com/cohort/array/DoubleArray.java
@@ -1197,12 +1197,28 @@ public class DoubleArray extends PrimitiveArray {
     }
     long byteCount = (long) size * elementSize();
     int elemSize = elementSize();
+    boolean swap = (byteOrder != java.nio.ByteOrder.nativeOrder());
+
+    if (!swap) {
+      java.nio.ByteBuffer buffer = null;
+      try {
+        buffer = array.asSlice(0, byteCount).asByteBuffer();
+      } catch (UnsupportedOperationException e) {
+        // Fallback for heap segments backed by non-byte arrays
+      }
+      if (buffer != null) {
+        while (buffer.hasRemaining()) {
+          channel.write(buffer);
+        }
+        return byteCount;
+      }
+    }
+
     PrimitiveArray.ScratchBuffer scratch = PrimitiveArray.SCRATCH_BUFFER.get();
     int chunkCapacity = scratch.bytes.length;
     java.lang.foreign.MemorySegment chunkSegment = scratch.segment;
     java.nio.ByteBuffer tempBuffer = scratch.buffer;
 
-    boolean swap = (byteOrder != java.nio.ByteOrder.nativeOrder());
     int offset = 0;
     while (offset < byteCount) {
       int len = (int) Math.min(byteCount - offset, chunkCapacity);

--- a/WEB-INF/classes/com/cohort/array/DoubleArray.java
+++ b/WEB-INF/classes/com/cohort/array/DoubleArray.java
@@ -1199,19 +1199,12 @@ public class DoubleArray extends PrimitiveArray {
     int elemSize = elementSize();
     boolean swap = (byteOrder != java.nio.ByteOrder.nativeOrder());
 
-    if (!swap) {
-      java.nio.ByteBuffer buffer = null;
-      try {
-        buffer = array.asSlice(0, byteCount).asByteBuffer();
-      } catch (UnsupportedOperationException e) {
-        // Fallback for heap segments backed by non-byte arrays
+    if (!swap && wrappedArray == null) {
+      java.nio.ByteBuffer buffer = array.asSlice(0, byteCount).asByteBuffer();
+      while (buffer.hasRemaining()) {
+        channel.write(buffer);
       }
-      if (buffer != null) {
-        while (buffer.hasRemaining()) {
-          channel.write(buffer);
-        }
-        return byteCount;
-      }
+      return byteCount;
     }
 
     PrimitiveArray.ScratchBuffer scratch = PrimitiveArray.SCRATCH_BUFFER.get();

--- a/WEB-INF/classes/com/cohort/array/DoubleArray.java
+++ b/WEB-INF/classes/com/cohort/array/DoubleArray.java
@@ -1197,12 +1197,10 @@ public class DoubleArray extends PrimitiveArray {
     }
     long byteCount = (long) size * elementSize();
     int elemSize = elementSize();
-    int chunkCapacity = (int) Math.min(byteCount, 65536);
-    chunkCapacity = (chunkCapacity / elemSize) * elemSize;
-    byte[] chunkBytes = new byte[chunkCapacity];
-    java.lang.foreign.MemorySegment chunkSegment =
-        java.lang.foreign.MemorySegment.ofArray(chunkBytes);
-    java.nio.ByteBuffer tempBuffer = java.nio.ByteBuffer.wrap(chunkBytes);
+    PrimitiveArray.ScratchBuffer scratch = PrimitiveArray.SCRATCH_BUFFER.get();
+    int chunkCapacity = scratch.bytes.length;
+    java.lang.foreign.MemorySegment chunkSegment = scratch.segment;
+    java.nio.ByteBuffer tempBuffer = scratch.buffer;
 
     boolean swap = (byteOrder != java.nio.ByteOrder.nativeOrder());
     int offset = 0;

--- a/WEB-INF/classes/com/cohort/array/FloatArray.java
+++ b/WEB-INF/classes/com/cohort/array/FloatArray.java
@@ -1196,6 +1196,52 @@ public class FloatArray extends PrimitiveArray {
    * @throws Exception if trouble
    */
   @Override
+  public long writeToChannel(java.nio.channels.FileChannel channel) throws java.io.IOException {
+    return writeToChannel(channel, java.nio.ByteOrder.nativeOrder());
+  }
+
+  @Override
+  public long writeToChannel(java.nio.channels.FileChannel channel, java.nio.ByteOrder byteOrder)
+      throws java.io.IOException {
+    if (size == 0) {
+      return 0L;
+    }
+    long byteCount = (long) size * elementSize();
+    int elemSize = elementSize();
+    int chunkCapacity = (int) Math.min(byteCount, 65536);
+    chunkCapacity = (chunkCapacity / elemSize) * elemSize;
+    byte[] chunkBytes = new byte[chunkCapacity];
+    java.lang.foreign.MemorySegment chunkSegment =
+        java.lang.foreign.MemorySegment.ofArray(chunkBytes);
+    java.nio.ByteBuffer tempBuffer = java.nio.ByteBuffer.wrap(chunkBytes);
+
+    boolean swap = (byteOrder != java.nio.ByteOrder.nativeOrder());
+    int offset = 0;
+    while (offset < byteCount) {
+      int len = (int) Math.min(byteCount - offset, chunkCapacity);
+      int numElems = len / elemSize;
+
+      java.lang.foreign.MemorySegment.copy(array, offset, chunkSegment, 0, len);
+
+      tempBuffer.clear();
+      tempBuffer.limit(len);
+
+      if (swap) {
+        java.nio.IntBuffer view = tempBuffer.asIntBuffer();
+        for (int i = 0; i < numElems; i++) {
+          view.put(i, Integer.reverseBytes(view.get(i)));
+        }
+      }
+
+      while (tempBuffer.hasRemaining()) {
+        channel.write(tempBuffer);
+      }
+      offset += len;
+    }
+    return byteCount;
+  }
+
+  @Override
   public int writeDos(final DataOutputStream dos) throws Exception {
     for (int i = 0; i < size; i++) dos.writeFloat(getArrayVal(i));
     return size == 0 ? 0 : 4;

--- a/WEB-INF/classes/com/cohort/array/FloatArray.java
+++ b/WEB-INF/classes/com/cohort/array/FloatArray.java
@@ -1208,12 +1208,10 @@ public class FloatArray extends PrimitiveArray {
     }
     long byteCount = (long) size * elementSize();
     int elemSize = elementSize();
-    int chunkCapacity = (int) Math.min(byteCount, 65536);
-    chunkCapacity = (chunkCapacity / elemSize) * elemSize;
-    byte[] chunkBytes = new byte[chunkCapacity];
-    java.lang.foreign.MemorySegment chunkSegment =
-        java.lang.foreign.MemorySegment.ofArray(chunkBytes);
-    java.nio.ByteBuffer tempBuffer = java.nio.ByteBuffer.wrap(chunkBytes);
+    PrimitiveArray.ScratchBuffer scratch = PrimitiveArray.SCRATCH_BUFFER.get();
+    int chunkCapacity = scratch.bytes.length;
+    java.lang.foreign.MemorySegment chunkSegment = scratch.segment;
+    java.nio.ByteBuffer tempBuffer = scratch.buffer;
 
     boolean swap = (byteOrder != java.nio.ByteOrder.nativeOrder());
     int offset = 0;

--- a/WEB-INF/classes/com/cohort/array/FloatArray.java
+++ b/WEB-INF/classes/com/cohort/array/FloatArray.java
@@ -1210,19 +1210,12 @@ public class FloatArray extends PrimitiveArray {
     int elemSize = elementSize();
     boolean swap = (byteOrder != java.nio.ByteOrder.nativeOrder());
 
-    if (!swap) {
-      java.nio.ByteBuffer buffer = null;
-      try {
-        buffer = array.asSlice(0, byteCount).asByteBuffer();
-      } catch (UnsupportedOperationException e) {
-        // Fallback for heap segments backed by non-byte arrays
+    if (!swap && wrappedArray == null) {
+      java.nio.ByteBuffer buffer = array.asSlice(0, byteCount).asByteBuffer();
+      while (buffer.hasRemaining()) {
+        channel.write(buffer);
       }
-      if (buffer != null) {
-        while (buffer.hasRemaining()) {
-          channel.write(buffer);
-        }
-        return byteCount;
-      }
+      return byteCount;
     }
 
     PrimitiveArray.ScratchBuffer scratch = PrimitiveArray.SCRATCH_BUFFER.get();

--- a/WEB-INF/classes/com/cohort/array/FloatArray.java
+++ b/WEB-INF/classes/com/cohort/array/FloatArray.java
@@ -1208,12 +1208,28 @@ public class FloatArray extends PrimitiveArray {
     }
     long byteCount = (long) size * elementSize();
     int elemSize = elementSize();
+    boolean swap = (byteOrder != java.nio.ByteOrder.nativeOrder());
+
+    if (!swap) {
+      java.nio.ByteBuffer buffer = null;
+      try {
+        buffer = array.asSlice(0, byteCount).asByteBuffer();
+      } catch (UnsupportedOperationException e) {
+        // Fallback for heap segments backed by non-byte arrays
+      }
+      if (buffer != null) {
+        while (buffer.hasRemaining()) {
+          channel.write(buffer);
+        }
+        return byteCount;
+      }
+    }
+
     PrimitiveArray.ScratchBuffer scratch = PrimitiveArray.SCRATCH_BUFFER.get();
     int chunkCapacity = scratch.bytes.length;
     java.lang.foreign.MemorySegment chunkSegment = scratch.segment;
     java.nio.ByteBuffer tempBuffer = scratch.buffer;
 
-    boolean swap = (byteOrder != java.nio.ByteOrder.nativeOrder());
     int offset = 0;
     while (offset < byteCount) {
       int len = (int) Math.min(byteCount - offset, chunkCapacity);

--- a/WEB-INF/classes/com/cohort/array/IntArray.java
+++ b/WEB-INF/classes/com/cohort/array/IntArray.java
@@ -1307,6 +1307,52 @@ public class IntArray extends PrimitiveArray {
    * @throws Exception if trouble
    */
   @Override
+  public long writeToChannel(java.nio.channels.FileChannel channel) throws java.io.IOException {
+    return writeToChannel(channel, java.nio.ByteOrder.nativeOrder());
+  }
+
+  @Override
+  public long writeToChannel(java.nio.channels.FileChannel channel, java.nio.ByteOrder byteOrder)
+      throws java.io.IOException {
+    if (size == 0) {
+      return 0L;
+    }
+    long byteCount = (long) size * elementSize();
+    int elemSize = elementSize();
+    int chunkCapacity = (int) Math.min(byteCount, 65536);
+    chunkCapacity = (chunkCapacity / elemSize) * elemSize;
+    byte[] chunkBytes = new byte[chunkCapacity];
+    java.lang.foreign.MemorySegment chunkSegment =
+        java.lang.foreign.MemorySegment.ofArray(chunkBytes);
+    java.nio.ByteBuffer tempBuffer = java.nio.ByteBuffer.wrap(chunkBytes);
+
+    boolean swap = (byteOrder != java.nio.ByteOrder.nativeOrder());
+    int offset = 0;
+    while (offset < byteCount) {
+      int len = (int) Math.min(byteCount - offset, chunkCapacity);
+      int numElems = len / elemSize;
+
+      java.lang.foreign.MemorySegment.copy(array, offset, chunkSegment, 0, len);
+
+      tempBuffer.clear();
+      tempBuffer.limit(len);
+
+      if (swap) {
+        java.nio.IntBuffer view = tempBuffer.asIntBuffer();
+        for (int i = 0; i < numElems; i++) {
+          view.put(i, Integer.reverseBytes(view.get(i)));
+        }
+      }
+
+      while (tempBuffer.hasRemaining()) {
+        channel.write(tempBuffer);
+      }
+      offset += len;
+    }
+    return byteCount;
+  }
+
+  @Override
   public int writeDos(final DataOutputStream dos) throws Exception {
     for (int i = 0; i < size; i++) dos.writeInt(getArrayVal(i));
     return size == 0 ? 0 : 4;

--- a/WEB-INF/classes/com/cohort/array/IntArray.java
+++ b/WEB-INF/classes/com/cohort/array/IntArray.java
@@ -1319,12 +1319,10 @@ public class IntArray extends PrimitiveArray {
     }
     long byteCount = (long) size * elementSize();
     int elemSize = elementSize();
-    int chunkCapacity = (int) Math.min(byteCount, 65536);
-    chunkCapacity = (chunkCapacity / elemSize) * elemSize;
-    byte[] chunkBytes = new byte[chunkCapacity];
-    java.lang.foreign.MemorySegment chunkSegment =
-        java.lang.foreign.MemorySegment.ofArray(chunkBytes);
-    java.nio.ByteBuffer tempBuffer = java.nio.ByteBuffer.wrap(chunkBytes);
+    PrimitiveArray.ScratchBuffer scratch = PrimitiveArray.SCRATCH_BUFFER.get();
+    int chunkCapacity = scratch.bytes.length;
+    java.lang.foreign.MemorySegment chunkSegment = scratch.segment;
+    java.nio.ByteBuffer tempBuffer = scratch.buffer;
 
     boolean swap = (byteOrder != java.nio.ByteOrder.nativeOrder());
     int offset = 0;

--- a/WEB-INF/classes/com/cohort/array/IntArray.java
+++ b/WEB-INF/classes/com/cohort/array/IntArray.java
@@ -1321,19 +1321,12 @@ public class IntArray extends PrimitiveArray {
     int elemSize = elementSize();
     boolean swap = (byteOrder != java.nio.ByteOrder.nativeOrder());
 
-    if (!swap) {
-      java.nio.ByteBuffer buffer = null;
-      try {
-        buffer = array.asSlice(0, byteCount).asByteBuffer();
-      } catch (UnsupportedOperationException e) {
-        // Fallback for heap segments backed by non-byte arrays
+    if (!swap && wrappedArray == null) {
+      java.nio.ByteBuffer buffer = array.asSlice(0, byteCount).asByteBuffer();
+      while (buffer.hasRemaining()) {
+        channel.write(buffer);
       }
-      if (buffer != null) {
-        while (buffer.hasRemaining()) {
-          channel.write(buffer);
-        }
-        return byteCount;
-      }
+      return byteCount;
     }
 
     PrimitiveArray.ScratchBuffer scratch = PrimitiveArray.SCRATCH_BUFFER.get();

--- a/WEB-INF/classes/com/cohort/array/IntArray.java
+++ b/WEB-INF/classes/com/cohort/array/IntArray.java
@@ -1319,12 +1319,28 @@ public class IntArray extends PrimitiveArray {
     }
     long byteCount = (long) size * elementSize();
     int elemSize = elementSize();
+    boolean swap = (byteOrder != java.nio.ByteOrder.nativeOrder());
+
+    if (!swap) {
+      java.nio.ByteBuffer buffer = null;
+      try {
+        buffer = array.asSlice(0, byteCount).asByteBuffer();
+      } catch (UnsupportedOperationException e) {
+        // Fallback for heap segments backed by non-byte arrays
+      }
+      if (buffer != null) {
+        while (buffer.hasRemaining()) {
+          channel.write(buffer);
+        }
+        return byteCount;
+      }
+    }
+
     PrimitiveArray.ScratchBuffer scratch = PrimitiveArray.SCRATCH_BUFFER.get();
     int chunkCapacity = scratch.bytes.length;
     java.lang.foreign.MemorySegment chunkSegment = scratch.segment;
     java.nio.ByteBuffer tempBuffer = scratch.buffer;
 
-    boolean swap = (byteOrder != java.nio.ByteOrder.nativeOrder());
     int offset = 0;
     while (offset < byteCount) {
       int len = (int) Math.min(byteCount - offset, chunkCapacity);

--- a/WEB-INF/classes/com/cohort/array/LongArray.java
+++ b/WEB-INF/classes/com/cohort/array/LongArray.java
@@ -1266,6 +1266,52 @@ public class LongArray extends PrimitiveArray {
    * @throws Exception if trouble
    */
   @Override
+  public long writeToChannel(java.nio.channels.FileChannel channel) throws java.io.IOException {
+    return writeToChannel(channel, java.nio.ByteOrder.nativeOrder());
+  }
+
+  @Override
+  public long writeToChannel(java.nio.channels.FileChannel channel, java.nio.ByteOrder byteOrder)
+      throws java.io.IOException {
+    if (size == 0) {
+      return 0L;
+    }
+    long byteCount = (long) size * elementSize();
+    int elemSize = elementSize();
+    int chunkCapacity = (int) Math.min(byteCount, 65536);
+    chunkCapacity = (chunkCapacity / elemSize) * elemSize;
+    byte[] chunkBytes = new byte[chunkCapacity];
+    java.lang.foreign.MemorySegment chunkSegment =
+        java.lang.foreign.MemorySegment.ofArray(chunkBytes);
+    java.nio.ByteBuffer tempBuffer = java.nio.ByteBuffer.wrap(chunkBytes);
+
+    boolean swap = (byteOrder != java.nio.ByteOrder.nativeOrder());
+    int offset = 0;
+    while (offset < byteCount) {
+      int len = (int) Math.min(byteCount - offset, chunkCapacity);
+      int numElems = len / elemSize;
+
+      java.lang.foreign.MemorySegment.copy(array, offset, chunkSegment, 0, len);
+
+      tempBuffer.clear();
+      tempBuffer.limit(len);
+
+      if (swap) {
+        java.nio.LongBuffer view = tempBuffer.asLongBuffer();
+        for (int i = 0; i < numElems; i++) {
+          view.put(i, Long.reverseBytes(view.get(i)));
+        }
+      }
+
+      while (tempBuffer.hasRemaining()) {
+        channel.write(tempBuffer);
+      }
+      offset += len;
+    }
+    return byteCount;
+  }
+
+  @Override
   public int writeDos(final DataOutputStream dos) throws Exception {
     for (int i = 0; i < size; i++) dos.writeLong(getArrayVal(i));
     return size == 0 ? 0 : 8;

--- a/WEB-INF/classes/com/cohort/array/LongArray.java
+++ b/WEB-INF/classes/com/cohort/array/LongArray.java
@@ -1280,19 +1280,12 @@ public class LongArray extends PrimitiveArray {
     int elemSize = elementSize();
     boolean swap = (byteOrder != java.nio.ByteOrder.nativeOrder());
 
-    if (!swap) {
-      java.nio.ByteBuffer buffer = null;
-      try {
-        buffer = array.asSlice(0, byteCount).asByteBuffer();
-      } catch (UnsupportedOperationException e) {
-        // Fallback for heap segments backed by non-byte arrays
+    if (!swap && wrappedArray == null) {
+      java.nio.ByteBuffer buffer = array.asSlice(0, byteCount).asByteBuffer();
+      while (buffer.hasRemaining()) {
+        channel.write(buffer);
       }
-      if (buffer != null) {
-        while (buffer.hasRemaining()) {
-          channel.write(buffer);
-        }
-        return byteCount;
-      }
+      return byteCount;
     }
 
     PrimitiveArray.ScratchBuffer scratch = PrimitiveArray.SCRATCH_BUFFER.get();

--- a/WEB-INF/classes/com/cohort/array/LongArray.java
+++ b/WEB-INF/classes/com/cohort/array/LongArray.java
@@ -1278,12 +1278,10 @@ public class LongArray extends PrimitiveArray {
     }
     long byteCount = (long) size * elementSize();
     int elemSize = elementSize();
-    int chunkCapacity = (int) Math.min(byteCount, 65536);
-    chunkCapacity = (chunkCapacity / elemSize) * elemSize;
-    byte[] chunkBytes = new byte[chunkCapacity];
-    java.lang.foreign.MemorySegment chunkSegment =
-        java.lang.foreign.MemorySegment.ofArray(chunkBytes);
-    java.nio.ByteBuffer tempBuffer = java.nio.ByteBuffer.wrap(chunkBytes);
+    PrimitiveArray.ScratchBuffer scratch = PrimitiveArray.SCRATCH_BUFFER.get();
+    int chunkCapacity = scratch.bytes.length;
+    java.lang.foreign.MemorySegment chunkSegment = scratch.segment;
+    java.nio.ByteBuffer tempBuffer = scratch.buffer;
 
     boolean swap = (byteOrder != java.nio.ByteOrder.nativeOrder());
     int offset = 0;

--- a/WEB-INF/classes/com/cohort/array/LongArray.java
+++ b/WEB-INF/classes/com/cohort/array/LongArray.java
@@ -1278,12 +1278,28 @@ public class LongArray extends PrimitiveArray {
     }
     long byteCount = (long) size * elementSize();
     int elemSize = elementSize();
+    boolean swap = (byteOrder != java.nio.ByteOrder.nativeOrder());
+
+    if (!swap) {
+      java.nio.ByteBuffer buffer = null;
+      try {
+        buffer = array.asSlice(0, byteCount).asByteBuffer();
+      } catch (UnsupportedOperationException e) {
+        // Fallback for heap segments backed by non-byte arrays
+      }
+      if (buffer != null) {
+        while (buffer.hasRemaining()) {
+          channel.write(buffer);
+        }
+        return byteCount;
+      }
+    }
+
     PrimitiveArray.ScratchBuffer scratch = PrimitiveArray.SCRATCH_BUFFER.get();
     int chunkCapacity = scratch.bytes.length;
     java.lang.foreign.MemorySegment chunkSegment = scratch.segment;
     java.nio.ByteBuffer tempBuffer = scratch.buffer;
 
-    boolean swap = (byteOrder != java.nio.ByteOrder.nativeOrder());
     int offset = 0;
     while (offset < byteCount) {
       int len = (int) Math.min(byteCount - offset, chunkCapacity);

--- a/WEB-INF/classes/com/cohort/array/PrimitiveArray.java
+++ b/WEB-INF/classes/com/cohort/array/PrimitiveArray.java
@@ -13,6 +13,8 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.math.BigInteger;
+import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
 import java.sql.Types;
 import java.text.MessageFormat;
 import java.util.ArrayList;
@@ -1775,6 +1777,25 @@ public abstract class PrimitiveArray {
    *     size=0, this returns 0.
    * @throws Exception if trouble
    */
+  /**
+   * Writes the active elements of this array directly to a FileChannel using native byte order.
+   *
+   * @param channel The open destination FileChannel.
+   * @return The total number of bytes written.
+   * @throws IOException If an I/O error occurs.
+   */
+  public abstract long writeToChannel(FileChannel channel) throws IOException;
+
+  /**
+   * Writes the active elements of this array directly to a FileChannel with specific byte ordering.
+   *
+   * @param channel The open destination FileChannel.
+   * @param byteOrder The desired ByteOrder (e.g., ByteOrder.BIG_ENDIAN or ByteOrder.LITTLE_ENDIAN).
+   * @return The total number of bytes written.
+   * @throws IOException If an I/O error occurs.
+   */
+  public abstract long writeToChannel(FileChannel channel, ByteOrder byteOrder) throws IOException;
+
   public abstract int writeDos(DataOutputStream dos) throws Exception;
 
   /**

--- a/WEB-INF/classes/com/cohort/array/PrimitiveArray.java
+++ b/WEB-INF/classes/com/cohort/array/PrimitiveArray.java
@@ -3915,4 +3915,14 @@ public abstract class PrimitiveArray {
     }
     return null;
   }
+
+  public static class ScratchBuffer {
+    public final byte[] bytes = new byte[65536];
+    public final java.lang.foreign.MemorySegment segment =
+        java.lang.foreign.MemorySegment.ofArray(bytes);
+    public final java.nio.ByteBuffer buffer = java.nio.ByteBuffer.wrap(bytes);
+  }
+
+  public static final ThreadLocal<ScratchBuffer> SCRATCH_BUFFER =
+      ThreadLocal.withInitial(ScratchBuffer::new);
 }

--- a/WEB-INF/classes/com/cohort/array/ShortArray.java
+++ b/WEB-INF/classes/com/cohort/array/ShortArray.java
@@ -1346,12 +1346,28 @@ public class ShortArray extends PrimitiveArray {
     }
     long byteCount = (long) size * elementSize();
     int elemSize = elementSize();
+    boolean swap = (byteOrder != java.nio.ByteOrder.nativeOrder());
+
+    if (!swap) {
+      java.nio.ByteBuffer buffer = null;
+      try {
+        buffer = array.asSlice(0, byteCount).asByteBuffer();
+      } catch (UnsupportedOperationException e) {
+        // Fallback for heap segments backed by non-byte arrays
+      }
+      if (buffer != null) {
+        while (buffer.hasRemaining()) {
+          channel.write(buffer);
+        }
+        return byteCount;
+      }
+    }
+
     PrimitiveArray.ScratchBuffer scratch = PrimitiveArray.SCRATCH_BUFFER.get();
     int chunkCapacity = scratch.bytes.length;
     java.lang.foreign.MemorySegment chunkSegment = scratch.segment;
     java.nio.ByteBuffer tempBuffer = scratch.buffer;
 
-    boolean swap = (byteOrder != java.nio.ByteOrder.nativeOrder());
     int offset = 0;
     while (offset < byteCount) {
       int len = (int) Math.min(byteCount - offset, chunkCapacity);

--- a/WEB-INF/classes/com/cohort/array/ShortArray.java
+++ b/WEB-INF/classes/com/cohort/array/ShortArray.java
@@ -1348,19 +1348,12 @@ public class ShortArray extends PrimitiveArray {
     int elemSize = elementSize();
     boolean swap = (byteOrder != java.nio.ByteOrder.nativeOrder());
 
-    if (!swap) {
-      java.nio.ByteBuffer buffer = null;
-      try {
-        buffer = array.asSlice(0, byteCount).asByteBuffer();
-      } catch (UnsupportedOperationException e) {
-        // Fallback for heap segments backed by non-byte arrays
+    if (!swap && wrappedArray == null) {
+      java.nio.ByteBuffer buffer = array.asSlice(0, byteCount).asByteBuffer();
+      while (buffer.hasRemaining()) {
+        channel.write(buffer);
       }
-      if (buffer != null) {
-        while (buffer.hasRemaining()) {
-          channel.write(buffer);
-        }
-        return byteCount;
-      }
+      return byteCount;
     }
 
     PrimitiveArray.ScratchBuffer scratch = PrimitiveArray.SCRATCH_BUFFER.get();

--- a/WEB-INF/classes/com/cohort/array/ShortArray.java
+++ b/WEB-INF/classes/com/cohort/array/ShortArray.java
@@ -1346,12 +1346,10 @@ public class ShortArray extends PrimitiveArray {
     }
     long byteCount = (long) size * elementSize();
     int elemSize = elementSize();
-    int chunkCapacity = (int) Math.min(byteCount, 65536);
-    chunkCapacity = (chunkCapacity / elemSize) * elemSize;
-    byte[] chunkBytes = new byte[chunkCapacity];
-    java.lang.foreign.MemorySegment chunkSegment =
-        java.lang.foreign.MemorySegment.ofArray(chunkBytes);
-    java.nio.ByteBuffer tempBuffer = java.nio.ByteBuffer.wrap(chunkBytes);
+    PrimitiveArray.ScratchBuffer scratch = PrimitiveArray.SCRATCH_BUFFER.get();
+    int chunkCapacity = scratch.bytes.length;
+    java.lang.foreign.MemorySegment chunkSegment = scratch.segment;
+    java.nio.ByteBuffer tempBuffer = scratch.buffer;
 
     boolean swap = (byteOrder != java.nio.ByteOrder.nativeOrder());
     int offset = 0;

--- a/WEB-INF/classes/com/cohort/array/ShortArray.java
+++ b/WEB-INF/classes/com/cohort/array/ShortArray.java
@@ -1334,6 +1334,52 @@ public class ShortArray extends PrimitiveArray {
    * @throws Exception if trouble
    */
   @Override
+  public long writeToChannel(java.nio.channels.FileChannel channel) throws java.io.IOException {
+    return writeToChannel(channel, java.nio.ByteOrder.nativeOrder());
+  }
+
+  @Override
+  public long writeToChannel(java.nio.channels.FileChannel channel, java.nio.ByteOrder byteOrder)
+      throws java.io.IOException {
+    if (size == 0) {
+      return 0L;
+    }
+    long byteCount = (long) size * elementSize();
+    int elemSize = elementSize();
+    int chunkCapacity = (int) Math.min(byteCount, 65536);
+    chunkCapacity = (chunkCapacity / elemSize) * elemSize;
+    byte[] chunkBytes = new byte[chunkCapacity];
+    java.lang.foreign.MemorySegment chunkSegment =
+        java.lang.foreign.MemorySegment.ofArray(chunkBytes);
+    java.nio.ByteBuffer tempBuffer = java.nio.ByteBuffer.wrap(chunkBytes);
+
+    boolean swap = (byteOrder != java.nio.ByteOrder.nativeOrder());
+    int offset = 0;
+    while (offset < byteCount) {
+      int len = (int) Math.min(byteCount - offset, chunkCapacity);
+      int numElems = len / elemSize;
+
+      java.lang.foreign.MemorySegment.copy(array, offset, chunkSegment, 0, len);
+
+      tempBuffer.clear();
+      tempBuffer.limit(len);
+
+      if (swap) {
+        java.nio.ShortBuffer view = tempBuffer.asShortBuffer();
+        for (int i = 0; i < numElems; i++) {
+          view.put(i, Short.reverseBytes(view.get(i)));
+        }
+      }
+
+      while (tempBuffer.hasRemaining()) {
+        channel.write(tempBuffer);
+      }
+      offset += len;
+    }
+    return byteCount;
+  }
+
+  @Override
   public int writeDos(final DataOutputStream dos) throws Exception {
     for (int i = 0; i < size; i++) dos.writeShort(getArrayVal(i));
     return size == 0 ? 0 : 2;

--- a/WEB-INF/classes/com/cohort/array/StringArray.java
+++ b/WEB-INF/classes/com/cohort/array/StringArray.java
@@ -1590,6 +1590,59 @@ public class StringArray extends PrimitiveArray {
    *     size=0, this returns 0.
    * @throws Exception if trouble
    */
+  private static class NonClosingOutputStream extends java.io.OutputStream {
+    private final java.nio.channels.FileChannel channel;
+    private final byte[] oneByte = new byte[1];
+
+    public NonClosingOutputStream(java.nio.channels.FileChannel channel) {
+      this.channel = channel;
+    }
+
+    @Override
+    public void write(int b) throws java.io.IOException {
+      oneByte[0] = (byte) b;
+      write(oneByte, 0, 1);
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws java.io.IOException {
+      java.nio.ByteBuffer buf = java.nio.ByteBuffer.wrap(b, off, len);
+      while (buf.hasRemaining()) {
+        channel.write(buf);
+      }
+    }
+  }
+
+  @Override
+  public long writeToChannel(java.nio.channels.FileChannel channel) throws java.io.IOException {
+    return writeToChannel(channel, java.nio.ByteOrder.nativeOrder());
+  }
+
+  @Override
+  public long writeToChannel(java.nio.channels.FileChannel channel, java.nio.ByteOrder byteOrder)
+      throws java.io.IOException {
+    if (size == 0) {
+      return 0L;
+    }
+    long startPos = channel.position();
+    NonClosingOutputStream ncos = new NonClosingOutputStream(channel);
+    java.io.BufferedOutputStream bos = new java.io.BufferedOutputStream(ncos, 65536);
+    java.io.DataOutputStream dos = new java.io.DataOutputStream(bos);
+    try {
+      for (int i = 0; i < size; i++) {
+        dos.writeUTF(get(i));
+      }
+      dos.flush();
+    } catch (Exception e) {
+      if (e instanceof java.io.IOException) {
+        throw (java.io.IOException) e;
+      } else {
+        throw new java.io.IOException(e);
+      }
+    }
+    return channel.position() - startPos;
+  }
+
   @Override
   public int writeDos(final DataOutputStream dos) throws Exception {
     for (int i = 0; i < size; i++) dos.writeUTF(get(i));

--- a/WEB-INF/classes/com/cohort/array/UByteArray.java
+++ b/WEB-INF/classes/com/cohort/array/UByteArray.java
@@ -1552,6 +1552,25 @@ public class UByteArray extends PrimitiveArray {
    * @throws Exception if trouble
    */
   @Override
+  public long writeToChannel(java.nio.channels.FileChannel channel) throws java.io.IOException {
+    return writeToChannel(channel, java.nio.ByteOrder.nativeOrder());
+  }
+
+  @Override
+  public long writeToChannel(java.nio.channels.FileChannel channel, java.nio.ByteOrder byteOrder)
+      throws java.io.IOException {
+    if (size == 0) {
+      return 0L;
+    }
+    long byteCount = (long) size * elementSize();
+    java.nio.ByteBuffer buffer = array.asSlice(0, byteCount).asByteBuffer();
+    while (buffer.hasRemaining()) {
+      channel.write(buffer);
+    }
+    return byteCount;
+  }
+
+  @Override
   public int writeDos(final DataOutputStream dos, final int i) throws Exception {
     dos.writeByte(getArrayVal(i));
     return 1;

--- a/WEB-INF/classes/com/cohort/array/UIntArray.java
+++ b/WEB-INF/classes/com/cohort/array/UIntArray.java
@@ -1408,12 +1408,28 @@ public class UIntArray extends PrimitiveArray {
     }
     long byteCount = (long) size * elementSize();
     int elemSize = elementSize();
+    boolean swap = (byteOrder != java.nio.ByteOrder.nativeOrder());
+
+    if (!swap) {
+      java.nio.ByteBuffer buffer = null;
+      try {
+        buffer = array.asSlice(0, byteCount).asByteBuffer();
+      } catch (UnsupportedOperationException e) {
+        // Fallback for heap segments backed by non-byte arrays
+      }
+      if (buffer != null) {
+        while (buffer.hasRemaining()) {
+          channel.write(buffer);
+        }
+        return byteCount;
+      }
+    }
+
     PrimitiveArray.ScratchBuffer scratch = PrimitiveArray.SCRATCH_BUFFER.get();
     int chunkCapacity = scratch.bytes.length;
     java.lang.foreign.MemorySegment chunkSegment = scratch.segment;
     java.nio.ByteBuffer tempBuffer = scratch.buffer;
 
-    boolean swap = (byteOrder != java.nio.ByteOrder.nativeOrder());
     int offset = 0;
     while (offset < byteCount) {
       int len = (int) Math.min(byteCount - offset, chunkCapacity);

--- a/WEB-INF/classes/com/cohort/array/UIntArray.java
+++ b/WEB-INF/classes/com/cohort/array/UIntArray.java
@@ -1408,12 +1408,10 @@ public class UIntArray extends PrimitiveArray {
     }
     long byteCount = (long) size * elementSize();
     int elemSize = elementSize();
-    int chunkCapacity = (int) Math.min(byteCount, 65536);
-    chunkCapacity = (chunkCapacity / elemSize) * elemSize;
-    byte[] chunkBytes = new byte[chunkCapacity];
-    java.lang.foreign.MemorySegment chunkSegment =
-        java.lang.foreign.MemorySegment.ofArray(chunkBytes);
-    java.nio.ByteBuffer tempBuffer = java.nio.ByteBuffer.wrap(chunkBytes);
+    PrimitiveArray.ScratchBuffer scratch = PrimitiveArray.SCRATCH_BUFFER.get();
+    int chunkCapacity = scratch.bytes.length;
+    java.lang.foreign.MemorySegment chunkSegment = scratch.segment;
+    java.nio.ByteBuffer tempBuffer = scratch.buffer;
 
     boolean swap = (byteOrder != java.nio.ByteOrder.nativeOrder());
     int offset = 0;

--- a/WEB-INF/classes/com/cohort/array/UIntArray.java
+++ b/WEB-INF/classes/com/cohort/array/UIntArray.java
@@ -1410,19 +1410,12 @@ public class UIntArray extends PrimitiveArray {
     int elemSize = elementSize();
     boolean swap = (byteOrder != java.nio.ByteOrder.nativeOrder());
 
-    if (!swap) {
-      java.nio.ByteBuffer buffer = null;
-      try {
-        buffer = array.asSlice(0, byteCount).asByteBuffer();
-      } catch (UnsupportedOperationException e) {
-        // Fallback for heap segments backed by non-byte arrays
+    if (!swap && wrappedArray == null) {
+      java.nio.ByteBuffer buffer = array.asSlice(0, byteCount).asByteBuffer();
+      while (buffer.hasRemaining()) {
+        channel.write(buffer);
       }
-      if (buffer != null) {
-        while (buffer.hasRemaining()) {
-          channel.write(buffer);
-        }
-        return byteCount;
-      }
+      return byteCount;
     }
 
     PrimitiveArray.ScratchBuffer scratch = PrimitiveArray.SCRATCH_BUFFER.get();

--- a/WEB-INF/classes/com/cohort/array/UIntArray.java
+++ b/WEB-INF/classes/com/cohort/array/UIntArray.java
@@ -1396,6 +1396,52 @@ public class UIntArray extends PrimitiveArray {
    * @throws Exception if trouble
    */
   @Override
+  public long writeToChannel(java.nio.channels.FileChannel channel) throws java.io.IOException {
+    return writeToChannel(channel, java.nio.ByteOrder.nativeOrder());
+  }
+
+  @Override
+  public long writeToChannel(java.nio.channels.FileChannel channel, java.nio.ByteOrder byteOrder)
+      throws java.io.IOException {
+    if (size == 0) {
+      return 0L;
+    }
+    long byteCount = (long) size * elementSize();
+    int elemSize = elementSize();
+    int chunkCapacity = (int) Math.min(byteCount, 65536);
+    chunkCapacity = (chunkCapacity / elemSize) * elemSize;
+    byte[] chunkBytes = new byte[chunkCapacity];
+    java.lang.foreign.MemorySegment chunkSegment =
+        java.lang.foreign.MemorySegment.ofArray(chunkBytes);
+    java.nio.ByteBuffer tempBuffer = java.nio.ByteBuffer.wrap(chunkBytes);
+
+    boolean swap = (byteOrder != java.nio.ByteOrder.nativeOrder());
+    int offset = 0;
+    while (offset < byteCount) {
+      int len = (int) Math.min(byteCount - offset, chunkCapacity);
+      int numElems = len / elemSize;
+
+      java.lang.foreign.MemorySegment.copy(array, offset, chunkSegment, 0, len);
+
+      tempBuffer.clear();
+      tempBuffer.limit(len);
+
+      if (swap) {
+        java.nio.IntBuffer view = tempBuffer.asIntBuffer();
+        for (int i = 0; i < numElems; i++) {
+          view.put(i, Integer.reverseBytes(view.get(i)));
+        }
+      }
+
+      while (tempBuffer.hasRemaining()) {
+        channel.write(tempBuffer);
+      }
+      offset += len;
+    }
+    return byteCount;
+  }
+
+  @Override
   public int writeDos(final DataOutputStream dos) throws Exception {
     for (int i = 0; i < size; i++) dos.writeInt(getArrayVal(i));
     return size == 0 ? 0 : 4;

--- a/WEB-INF/classes/com/cohort/array/ULongArray.java
+++ b/WEB-INF/classes/com/cohort/array/ULongArray.java
@@ -1433,12 +1433,10 @@ public class ULongArray extends PrimitiveArray {
     }
     long byteCount = (long) size * elementSize();
     int elemSize = elementSize();
-    int chunkCapacity = (int) Math.min(byteCount, 65536);
-    chunkCapacity = (chunkCapacity / elemSize) * elemSize;
-    byte[] chunkBytes = new byte[chunkCapacity];
-    java.lang.foreign.MemorySegment chunkSegment =
-        java.lang.foreign.MemorySegment.ofArray(chunkBytes);
-    java.nio.ByteBuffer tempBuffer = java.nio.ByteBuffer.wrap(chunkBytes);
+    PrimitiveArray.ScratchBuffer scratch = PrimitiveArray.SCRATCH_BUFFER.get();
+    int chunkCapacity = scratch.bytes.length;
+    java.lang.foreign.MemorySegment chunkSegment = scratch.segment;
+    java.nio.ByteBuffer tempBuffer = scratch.buffer;
 
     boolean swap = (byteOrder != java.nio.ByteOrder.nativeOrder());
     int offset = 0;

--- a/WEB-INF/classes/com/cohort/array/ULongArray.java
+++ b/WEB-INF/classes/com/cohort/array/ULongArray.java
@@ -1435,19 +1435,12 @@ public class ULongArray extends PrimitiveArray {
     int elemSize = elementSize();
     boolean swap = (byteOrder != java.nio.ByteOrder.nativeOrder());
 
-    if (!swap) {
-      java.nio.ByteBuffer buffer = null;
-      try {
-        buffer = array.asSlice(0, byteCount).asByteBuffer();
-      } catch (UnsupportedOperationException e) {
-        // Fallback for heap segments backed by non-byte arrays
+    if (!swap && wrappedArray == null) {
+      java.nio.ByteBuffer buffer = array.asSlice(0, byteCount).asByteBuffer();
+      while (buffer.hasRemaining()) {
+        channel.write(buffer);
       }
-      if (buffer != null) {
-        while (buffer.hasRemaining()) {
-          channel.write(buffer);
-        }
-        return byteCount;
-      }
+      return byteCount;
     }
 
     PrimitiveArray.ScratchBuffer scratch = PrimitiveArray.SCRATCH_BUFFER.get();

--- a/WEB-INF/classes/com/cohort/array/ULongArray.java
+++ b/WEB-INF/classes/com/cohort/array/ULongArray.java
@@ -1433,12 +1433,28 @@ public class ULongArray extends PrimitiveArray {
     }
     long byteCount = (long) size * elementSize();
     int elemSize = elementSize();
+    boolean swap = (byteOrder != java.nio.ByteOrder.nativeOrder());
+
+    if (!swap) {
+      java.nio.ByteBuffer buffer = null;
+      try {
+        buffer = array.asSlice(0, byteCount).asByteBuffer();
+      } catch (UnsupportedOperationException e) {
+        // Fallback for heap segments backed by non-byte arrays
+      }
+      if (buffer != null) {
+        while (buffer.hasRemaining()) {
+          channel.write(buffer);
+        }
+        return byteCount;
+      }
+    }
+
     PrimitiveArray.ScratchBuffer scratch = PrimitiveArray.SCRATCH_BUFFER.get();
     int chunkCapacity = scratch.bytes.length;
     java.lang.foreign.MemorySegment chunkSegment = scratch.segment;
     java.nio.ByteBuffer tempBuffer = scratch.buffer;
 
-    boolean swap = (byteOrder != java.nio.ByteOrder.nativeOrder());
     int offset = 0;
     while (offset < byteCount) {
       int len = (int) Math.min(byteCount - offset, chunkCapacity);

--- a/WEB-INF/classes/com/cohort/array/ULongArray.java
+++ b/WEB-INF/classes/com/cohort/array/ULongArray.java
@@ -1421,6 +1421,52 @@ public class ULongArray extends PrimitiveArray {
    * @throws Exception if trouble
    */
   @Override
+  public long writeToChannel(java.nio.channels.FileChannel channel) throws java.io.IOException {
+    return writeToChannel(channel, java.nio.ByteOrder.nativeOrder());
+  }
+
+  @Override
+  public long writeToChannel(java.nio.channels.FileChannel channel, java.nio.ByteOrder byteOrder)
+      throws java.io.IOException {
+    if (size == 0) {
+      return 0L;
+    }
+    long byteCount = (long) size * elementSize();
+    int elemSize = elementSize();
+    int chunkCapacity = (int) Math.min(byteCount, 65536);
+    chunkCapacity = (chunkCapacity / elemSize) * elemSize;
+    byte[] chunkBytes = new byte[chunkCapacity];
+    java.lang.foreign.MemorySegment chunkSegment =
+        java.lang.foreign.MemorySegment.ofArray(chunkBytes);
+    java.nio.ByteBuffer tempBuffer = java.nio.ByteBuffer.wrap(chunkBytes);
+
+    boolean swap = (byteOrder != java.nio.ByteOrder.nativeOrder());
+    int offset = 0;
+    while (offset < byteCount) {
+      int len = (int) Math.min(byteCount - offset, chunkCapacity);
+      int numElems = len / elemSize;
+
+      java.lang.foreign.MemorySegment.copy(array, offset, chunkSegment, 0, len);
+
+      tempBuffer.clear();
+      tempBuffer.limit(len);
+
+      if (swap) {
+        java.nio.LongBuffer view = tempBuffer.asLongBuffer();
+        for (int i = 0; i < numElems; i++) {
+          view.put(i, Long.reverseBytes(view.get(i)));
+        }
+      }
+
+      while (tempBuffer.hasRemaining()) {
+        channel.write(tempBuffer);
+      }
+      offset += len;
+    }
+    return byteCount;
+  }
+
+  @Override
   public int writeDos(final DataOutputStream dos) throws Exception {
     for (int i = 0; i < size; i++) dos.writeLong(getArrayVal(i));
     return size == 0 ? 0 : 8;

--- a/WEB-INF/classes/com/cohort/array/UShortArray.java
+++ b/WEB-INF/classes/com/cohort/array/UShortArray.java
@@ -1430,6 +1430,52 @@ public class UShortArray extends PrimitiveArray {
    * @throws Exception if trouble
    */
   @Override
+  public long writeToChannel(java.nio.channels.FileChannel channel) throws java.io.IOException {
+    return writeToChannel(channel, java.nio.ByteOrder.nativeOrder());
+  }
+
+  @Override
+  public long writeToChannel(java.nio.channels.FileChannel channel, java.nio.ByteOrder byteOrder)
+      throws java.io.IOException {
+    if (size == 0) {
+      return 0L;
+    }
+    long byteCount = (long) size * elementSize();
+    int elemSize = elementSize();
+    int chunkCapacity = (int) Math.min(byteCount, 65536);
+    chunkCapacity = (chunkCapacity / elemSize) * elemSize;
+    byte[] chunkBytes = new byte[chunkCapacity];
+    java.lang.foreign.MemorySegment chunkSegment =
+        java.lang.foreign.MemorySegment.ofArray(chunkBytes);
+    java.nio.ByteBuffer tempBuffer = java.nio.ByteBuffer.wrap(chunkBytes);
+
+    boolean swap = (byteOrder != java.nio.ByteOrder.nativeOrder());
+    int offset = 0;
+    while (offset < byteCount) {
+      int len = (int) Math.min(byteCount - offset, chunkCapacity);
+      int numElems = len / elemSize;
+
+      java.lang.foreign.MemorySegment.copy(array, offset, chunkSegment, 0, len);
+
+      tempBuffer.clear();
+      tempBuffer.limit(len);
+
+      if (swap) {
+        java.nio.ShortBuffer view = tempBuffer.asShortBuffer();
+        for (int i = 0; i < numElems; i++) {
+          view.put(i, Short.reverseBytes(view.get(i)));
+        }
+      }
+
+      while (tempBuffer.hasRemaining()) {
+        channel.write(tempBuffer);
+      }
+      offset += len;
+    }
+    return byteCount;
+  }
+
+  @Override
   public int writeDos(final DataOutputStream dos) throws Exception {
     for (int i = 0; i < size; i++) dos.writeShort(getArrayVal(i));
     return size == 0 ? 0 : 2;

--- a/WEB-INF/classes/com/cohort/array/UShortArray.java
+++ b/WEB-INF/classes/com/cohort/array/UShortArray.java
@@ -1442,12 +1442,10 @@ public class UShortArray extends PrimitiveArray {
     }
     long byteCount = (long) size * elementSize();
     int elemSize = elementSize();
-    int chunkCapacity = (int) Math.min(byteCount, 65536);
-    chunkCapacity = (chunkCapacity / elemSize) * elemSize;
-    byte[] chunkBytes = new byte[chunkCapacity];
-    java.lang.foreign.MemorySegment chunkSegment =
-        java.lang.foreign.MemorySegment.ofArray(chunkBytes);
-    java.nio.ByteBuffer tempBuffer = java.nio.ByteBuffer.wrap(chunkBytes);
+    PrimitiveArray.ScratchBuffer scratch = PrimitiveArray.SCRATCH_BUFFER.get();
+    int chunkCapacity = scratch.bytes.length;
+    java.lang.foreign.MemorySegment chunkSegment = scratch.segment;
+    java.nio.ByteBuffer tempBuffer = scratch.buffer;
 
     boolean swap = (byteOrder != java.nio.ByteOrder.nativeOrder());
     int offset = 0;

--- a/WEB-INF/classes/com/cohort/array/UShortArray.java
+++ b/WEB-INF/classes/com/cohort/array/UShortArray.java
@@ -1444,19 +1444,12 @@ public class UShortArray extends PrimitiveArray {
     int elemSize = elementSize();
     boolean swap = (byteOrder != java.nio.ByteOrder.nativeOrder());
 
-    if (!swap) {
-      java.nio.ByteBuffer buffer = null;
-      try {
-        buffer = array.asSlice(0, byteCount).asByteBuffer();
-      } catch (UnsupportedOperationException e) {
-        // Fallback for heap segments backed by non-byte arrays
+    if (!swap && wrappedArray == null) {
+      java.nio.ByteBuffer buffer = array.asSlice(0, byteCount).asByteBuffer();
+      while (buffer.hasRemaining()) {
+        channel.write(buffer);
       }
-      if (buffer != null) {
-        while (buffer.hasRemaining()) {
-          channel.write(buffer);
-        }
-        return byteCount;
-      }
+      return byteCount;
     }
 
     PrimitiveArray.ScratchBuffer scratch = PrimitiveArray.SCRATCH_BUFFER.get();

--- a/WEB-INF/classes/com/cohort/array/UShortArray.java
+++ b/WEB-INF/classes/com/cohort/array/UShortArray.java
@@ -1442,12 +1442,28 @@ public class UShortArray extends PrimitiveArray {
     }
     long byteCount = (long) size * elementSize();
     int elemSize = elementSize();
+    boolean swap = (byteOrder != java.nio.ByteOrder.nativeOrder());
+
+    if (!swap) {
+      java.nio.ByteBuffer buffer = null;
+      try {
+        buffer = array.asSlice(0, byteCount).asByteBuffer();
+      } catch (UnsupportedOperationException e) {
+        // Fallback for heap segments backed by non-byte arrays
+      }
+      if (buffer != null) {
+        while (buffer.hasRemaining()) {
+          channel.write(buffer);
+        }
+        return byteCount;
+      }
+    }
+
     PrimitiveArray.ScratchBuffer scratch = PrimitiveArray.SCRATCH_BUFFER.get();
     int chunkCapacity = scratch.bytes.length;
     java.lang.foreign.MemorySegment chunkSegment = scratch.segment;
     java.nio.ByteBuffer tempBuffer = scratch.buffer;
 
-    boolean swap = (byteOrder != java.nio.ByteOrder.nativeOrder());
     int offset = 0;
     while (offset < byteCount) {
       int len = (int) Math.min(byteCount - offset, chunkCapacity);

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/GridDataAllAccessor.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/GridDataAllAccessor.java
@@ -11,10 +11,7 @@ import com.cohort.util.Math2;
 import com.cohort.util.MustBe;
 import com.cohort.util.String2;
 import gov.noaa.pfel.erddap.variable.EDV;
-import java.io.BufferedOutputStream;
 import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.nio.file.Files;
 import java.nio.file.Paths;
 
 /**
@@ -48,7 +45,7 @@ public class GridDataAllAccessor implements AutoCloseable {
   public GridDataAllAccessor(GridDataAccessor tGridDataAccessor) throws Throwable {
 
     int nDv = 0;
-    DataOutputStream dos[] = null;
+    java.nio.channels.FileChannel[] channels = null;
     gridDataAccessor = tGridDataAccessor;
     try {
       if (!gridDataAccessor.rowMajor())
@@ -70,25 +67,30 @@ public class GridDataAllAccessor implements AutoCloseable {
               + "_"; // so two identical queries don't interfere with each other
 
       dataPAType = new PAType[nDv];
-      dos = new DataOutputStream[nDv]; // 1 per data variable
+      channels = new java.nio.channels.FileChannel[nDv]; // 1 per data variable
       for (int dv = 0; dv < nDv; dv++) {
         dataPAType[dv] = dataVars[dv].destinationDataPAType();
-        dos[dv] =
-            new DataOutputStream(
-                new BufferedOutputStream(Files.newOutputStream(Paths.get(baseFileName + dv))));
+        channels[dv] =
+            java.nio.channels.FileChannel.open(
+                Paths.get(baseFileName + dv),
+                java.nio.file.StandardOpenOption.CREATE,
+                java.nio.file.StandardOpenOption.WRITE,
+                java.nio.file.StandardOpenOption.TRUNCATE_EXISTING);
       }
 
       // get all the data
       while (gridDataAccessor.incrementChunk()) {
         for (int dv = 0; dv < nDv; dv++) {
-          gridDataAccessor.getPartialDataValues(dv).writeDos(dos[dv]);
+          gridDataAccessor
+              .getPartialDataValues(dv)
+              .writeToChannel(channels[dv], java.nio.ByteOrder.BIG_ENDIAN);
         }
       }
     } finally {
-      if (dos != null) {
+      if (channels != null) {
         for (int dv = 0; dv < nDv; dv++)
           try {
-            if (dos[dv] != null) dos[dv].close();
+            if (channels[dv] != null) channels[dv].close();
           } catch (Exception e) {
           }
       }

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/TableWriterAll.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/TableWriterAll.java
@@ -13,10 +13,7 @@ import com.cohort.util.String2;
 import com.cohort.util.Test;
 import gov.noaa.pfel.coastwatch.pointdata.Table;
 import gov.noaa.pfel.erddap.util.EDStatic;
-import java.io.BufferedOutputStream;
 import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.nio.file.Files;
 import java.nio.file.Paths;
 
 /**
@@ -41,7 +38,7 @@ public class TableWriterAll extends TableWriter {
   // set firstTime
   // POLICY: because this class may be used in more than one thread,
   // each instance makes unique temp files names by adding randomInt to name.
-  protected volatile DataOutputStream[] columnStreams;
+  protected volatile java.nio.channels.FileChannel[] columnChannels;
   protected volatile long totalNRows = 0;
 
   protected Table cumulativeTable; // set by writeAllAndFinish, if used
@@ -72,7 +69,7 @@ public class TableWriterAll extends TableWriter {
 
   private static final class CleanupTableWriterAction implements Runnable {
 
-    private DataOutputStream[] columnStreams;
+    private java.nio.channels.FileChannel[] columnChannels;
     private String[] columnNames;
     private final String dir;
     private final String fileNameNoExt;
@@ -84,25 +81,24 @@ public class TableWriterAll extends TableWriter {
       this.randomInt = randomInt;
     }
 
-    private void setColumnStreams(DataOutputStream[] columnStreams) {
-      this.columnStreams = columnStreams;
+    private void setColumnChannels(java.nio.channels.FileChannel[] columnChannels) {
+      this.columnChannels = columnChannels;
     }
 
     @Override
     public void run() {
       try {
-        // delete columnStreams (if it was still saving data)
-        if (columnStreams != null) {
-          for (int col = 0; col < columnStreams.length; col++) {
-            // close the stream
+        // delete columnChannels (if it was still saving data)
+        if (columnChannels != null) {
+          for (int col = 0; col < columnChannels.length; col++) {
+            // close the channel
             try {
-              if (columnStreams[col] != null) columnStreams[col].close();
+              if (columnChannels[col] != null) columnChannels[col].close();
             } catch (Exception e) {
             }
-            // an attempt to solve File2.delete problem on these files: it couldn't hurt
-            columnStreams[col] = null;
+            columnChannels[col] = null;
           }
-          columnStreams = null;
+          columnChannels = null;
         }
 
         // delete the files
@@ -150,14 +146,17 @@ public class TableWriterAll extends TableWriter {
     // do firstTime stuff
     int nColumns = table.nColumns();
     if (firstTime) {
-      columnStreams = new DataOutputStream[nColumns];
-      cleanupAction.setColumnStreams(columnStreams);
+      columnChannels = new java.nio.channels.FileChannel[nColumns];
+      cleanupAction.setColumnChannels(columnChannels);
       cleanupAction.setColumnNames(columnNames);
       for (int col = 0; col < nColumns; col++) {
         String tFileName = columnFileName(col);
-        columnStreams[col] =
-            new DataOutputStream(
-                new BufferedOutputStream(Files.newOutputStream(Paths.get(tFileName))));
+        columnChannels[col] =
+            java.nio.channels.FileChannel.open(
+                Paths.get(tFileName),
+                java.nio.file.StandardOpenOption.CREATE,
+                java.nio.file.StandardOpenOption.WRITE,
+                java.nio.file.StandardOpenOption.APPEND);
         if (col == 0 && reallyVerbose)
           String2.log(
               "TableWriterAll nColumns="
@@ -180,9 +179,9 @@ public class TableWriterAll extends TableWriter {
     // write the data
     for (int col = 0; col < nColumns; col++) {
       Test.ensureNotNull(
-          columnStreams[col], "columnStreams[" + col + "] is null! nColumns=" + nColumns);
+          columnChannels[col], "columnChannels[" + col + "] is null! nColumns=" + nColumns);
       PrimitiveArray pa = table.getColumn(col);
-      pa.writeDos(columnStreams[col]);
+      pa.writeToChannel(columnChannels[col], java.nio.ByteOrder.BIG_ENDIAN);
     }
     totalNRows = newTotalNRows;
   }
@@ -198,18 +197,18 @@ public class TableWriterAll extends TableWriter {
     if (ignoreFinish) return;
 
     // check for MustBe.THERE_IS_NO_DATA
-    if (columnStreams == null) throw new SimpleException(MustBe.THERE_IS_NO_DATA + " (nRows = 0)");
-    // String2.log("TableWriterAll.finish  n columnStreams=" + columnStreams.length);
-    for (int col = 0; col < columnStreams.length; col++) {
+    if (columnChannels == null) throw new SimpleException(MustBe.THERE_IS_NO_DATA + " (nRows = 0)");
+    // String2.log("TableWriterAll.finish  n columnChannels=" + columnChannels.length);
+    for (int col = 0; col < columnChannels.length; col++) {
       // close the stream
       try {
-        if (columnStreams[col] != null) columnStreams[col].close();
+        if (columnChannels[col] != null) columnChannels[col].close();
       } catch (Exception e) {
       }
       // an attempt to solve File2.delete problem on these files: it couldn't hurt
-      columnStreams[col] = null;
+      columnChannels[col] = null;
     }
-    columnStreams = null;
+    columnChannels = null;
 
     // diagnostic
     if (verbose)
@@ -333,18 +332,18 @@ public class TableWriterAll extends TableWriter {
     try {
       cumulativeTable = null;
 
-      // delete columnStreams (if it was still saving data)
-      if (columnStreams != null) {
-        for (int col = 0; col < columnStreams.length; col++) {
+      // delete columnChannels (if it was still saving data)
+      if (columnChannels != null) {
+        for (int col = 0; col < columnChannels.length; col++) {
           // close the stream
           try {
-            if (columnStreams[col] != null) columnStreams[col].close();
+            if (columnChannels[col] != null) columnChannels[col].close();
           } catch (Exception e) {
           }
           // an attempt to solve File2.delete problem on these files: it couldn't hurt
-          columnStreams[col] = null;
+          columnChannels[col] = null;
         }
-        columnStreams = null;
+        columnChannels = null;
       }
 
       // delete the files

--- a/src/test/java/com/cohort/array/PrimitiveArrayTests.java
+++ b/src/test/java/com/cohort/array/PrimitiveArrayTests.java
@@ -1487,4 +1487,83 @@ class PrimitiveArrayTests {
             + (System.currentTimeMillis() - tTime)
             + " (Java 1.8 31ms, 1.7M4700 32ms, 2012-06-29: 282 ms)");
   }
+
+  @org.junit.jupiter.api.Test
+  void testWriteToChannel() throws Throwable {
+    String2.log("*** PrimitiveArrayTests.testWriteToChannel");
+    PAType[] types = PAType.values();
+    for (PAType type : types) {
+      if (type == PAType.BOOLEAN) continue;
+      PrimitiveArray pa = PrimitiveArray.factory(type, 10, false);
+      if (type == PAType.STRING) {
+        pa.addString("Hello");
+        pa.addString("World");
+        pa.addString("Testing 1 2 3");
+      } else {
+        for (int i = 0; i < 10; i++) {
+          pa.addDouble(i * 1.5);
+        }
+      }
+
+      // 1. Test BIG_ENDIAN writeToChannel vs legacy writeDos
+      String fileDos = File2.getSystemTempDirectory() + "/testDos_" + type + ".bin";
+      String fileChannelBE = File2.getSystemTempDirectory() + "/testChannelBE_" + type + ".bin";
+
+      // legacy writeDos
+      try (java.io.DataOutputStream dos =
+          new java.io.DataOutputStream(
+              new java.io.BufferedOutputStream(
+                  java.nio.file.Files.newOutputStream(java.nio.file.Paths.get(fileDos))))) {
+        pa.writeDos(dos);
+      }
+
+      // new writeToChannel Big Endian
+      try (java.nio.channels.FileChannel channel =
+          java.nio.channels.FileChannel.open(
+              java.nio.file.Paths.get(fileChannelBE),
+              java.nio.file.StandardOpenOption.CREATE,
+              java.nio.file.StandardOpenOption.WRITE,
+              java.nio.file.StandardOpenOption.TRUNCATE_EXISTING)) {
+        pa.writeToChannel(channel, java.nio.ByteOrder.BIG_ENDIAN);
+      }
+
+      // assert binary identical
+      byte[] bytesDos = java.nio.file.Files.readAllBytes(java.nio.file.Paths.get(fileDos));
+      byte[] bytesChannelBE =
+          java.nio.file.Files.readAllBytes(java.nio.file.Paths.get(fileChannelBE));
+      Test.ensureTrue(Arrays.equals(bytesDos, bytesChannelBE), "Mismatch in BE for type: " + type);
+
+      // Clean up files
+      File2.delete(fileDos);
+      File2.delete(fileChannelBE);
+
+      // 2. Test LITTLE_ENDIAN writeToChannel (not applicable to StringArray since it's UTF-8)
+      if (type != PAType.STRING) {
+        String fileChannelLE = File2.getSystemTempDirectory() + "/testChannelLE_" + type + ".bin";
+        try (java.nio.channels.FileChannel channel =
+            java.nio.channels.FileChannel.open(
+                java.nio.file.Paths.get(fileChannelLE),
+                java.nio.file.StandardOpenOption.CREATE,
+                java.nio.file.StandardOpenOption.WRITE,
+                java.nio.file.StandardOpenOption.TRUNCATE_EXISTING)) {
+          pa.writeToChannel(channel, java.nio.ByteOrder.LITTLE_ENDIAN);
+        }
+
+        // Compare by reading back and ensuring values are correct
+        PrimitiveArray paRead = PrimitiveArray.factory(type, 10, false);
+        try (java.io.DataInputStream dis =
+            new java.io.DataInputStream(
+                java.nio.file.Files.newInputStream(java.nio.file.Paths.get(fileChannelLE)))) {
+          paRead.readDis(dis, pa.size());
+        }
+        paRead.reverseBytes(); // reverse LITTLE_ENDIAN back to native
+        for (int i = 0; i < pa.size(); i++) {
+          Test.ensureEqual(
+              pa.getString(i), paRead.getString(i), "Mismatch at LE readback for type: " + type);
+        }
+        File2.delete(fileChannelLE);
+      }
+    }
+    String2.log("testWriteToChannel passed successfully!");
+  }
 }


### PR DESCRIPTION
Implemented bulk FileChannel writing across all 11 fixed-size subclasses of PrimitiveArray and StringArray. Refactored TableWriterAll and GridDataAllAccessor to write columns in bulk using FileChannel instead of slow element-by-element DataOutputStream. Verified binary compatibility and endianness handling with a new testWriteToChannel unit test.

---
*PR created automatically by Jules for task [17858605486445584652](https://jules.google.com/task/17858605486445584652) started by @ChrisJohnNOAA*