### PR TITLE
Add native ByteOrder FileChannel bulk I/O methods to PrimitiveArray and subclasses

### DIFF
--- a/WEB-INF/classes/com/cohort/array/ByteArray.java
+++ b/WEB-INF/classes/com/cohort/array/ByteArray.java
@@ -10,6 +10,10 @@ import com.cohort.util.Math2;
 import com.cohort.util.String2;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
+import java.io.EOFException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.RandomAccessFile;
@@ -1336,6 +1340,106 @@ public class ByteArray extends PrimitiveArray {
   @Override
   public void reverseBytes() {
     // ByteArray does nothing
+  }
+
+  /**
+   * This writes the active elements (0 ... size-1) to a FileChannel using native byte order.
+   *
+   * @param channel the FileChannel
+   * @return the number of bytes written
+   * @throws Exception if trouble
+   */
+  @Override
+  public long writeToChannel(final FileChannel channel) throws Exception {
+    return writeToChannel(channel, 0, size);
+  }
+
+  /**
+   * This writes a subset of elements (offset ... offset+length-1) to a FileChannel using native byte order.
+   *
+   * @param channel the FileChannel
+   * @param offset the starting index
+   * @param length the number of elements to write
+   * @return the number of bytes written
+   * @throws Exception if trouble
+   */
+  @Override
+  public long writeToChannel(final FileChannel channel, final int offset, final int length) throws Exception {
+    if (channel == null) {
+      throw new IllegalArgumentException(String2.ERROR + " in ByteArray.writeToChannel: FileChannel is null.");
+    }
+    if (offset < 0) {
+      throw new IllegalArgumentException(
+          String2.ERROR + " in ByteArray.writeToChannel: offset (" + offset + ") < 0.");
+    }
+    if (length < 0) {
+      throw new IllegalArgumentException(
+          String2.ERROR + " in ByteArray.writeToChannel: length (" + length + ") < 0.");
+    }
+    if (offset + (long) length > size) {
+      throw new IllegalArgumentException(
+          String2.ERROR
+              + " in ByteArray.writeToChannel: offset + length ("
+              + (offset + (long) length)
+              + ") > size ("
+              + size
+              + ").");
+    }
+    if (length == 0) {
+      return 0L;
+    }
+    final int bytesPerElement = 1;
+    final int byteSize = length * bytesPerElement;
+    final ByteBuffer byteBuf = ByteBuffer.wrap(array, offset, length).order(ByteOrder.nativeOrder());
+    long totalBytesWritten = 0;
+    while (byteBuf.hasRemaining()) {
+      final int written = channel.write(byteBuf);
+      if (written == 0) {
+        Thread.sleep(1);
+      }
+      totalBytesWritten += written;
+    }
+    return totalBytesWritten;
+  }
+
+  /**
+   * This reads/adds n elements from a FileChannel using native byte order.
+   *
+   * @param channel the FileChannel
+   * @param n the number of elements to read
+   * @throws Exception if trouble
+   */
+  @Override
+  public void readFromChannel(final FileChannel channel, final int n) throws Exception {
+    if (channel == null) {
+      throw new IllegalArgumentException(String2.ERROR + " in ByteArray.readFromChannel: FileChannel is null.");
+    }
+    if (n < 0) {
+      throw new IllegalArgumentException(
+          String2.ERROR + " in ByteArray.readFromChannel: n (" + n + ") < 0.");
+    }
+    if (n == 0) {
+      return;
+    }
+    ensureCapacity(size + (long) n);
+    final int bytesPerElement = 1;
+    final int bytesToRead = n * bytesPerElement;
+    final ByteBuffer byteBuf = ByteBuffer.wrap(array, size, n).order(ByteOrder.nativeOrder());
+    int totalBytesRead = 0;
+    while (totalBytesRead < bytesToRead) {
+      final int read = channel.read(byteBuf);
+      if (read == -1) {
+        throw new EOFException(
+            String2.ERROR
+                + " in ByteArray.readFromChannel: EOF reached after reading "
+                + totalBytesRead
+                + " of "
+                + bytesToRead
+                + " bytes.");
+      }
+      totalBytesRead += read;
+    }
+    size += n;
   }
 
   /**

--- a/WEB-INF/classes/com/cohort/array/CharArray.java
+++ b/WEB-INF/classes/com/cohort/array/CharArray.java
@@ -9,6 +9,10 @@ import com.cohort.util.Math2;
 import com.cohort.util.String2;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
+import java.io.EOFException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.math.BigInteger;
@@ -1295,6 +1299,112 @@ public class CharArray extends PrimitiveArray {
   @Override
   public void reverseBytes() {
     for (int i = 0; i < size; i++) array[i] = Character.reverseBytes(array[i]);
+  }
+
+  /**
+   * This writes the active elements (0 ... size-1) to a FileChannel using native byte order.
+   *
+   * @param channel the FileChannel
+   * @return the number of bytes written
+   * @throws Exception if trouble
+   */
+  @Override
+  public long writeToChannel(final FileChannel channel) throws Exception {
+    return writeToChannel(channel, 0, size);
+  }
+
+  /**
+   * This writes a subset of elements (offset ... offset+length-1) to a FileChannel using native byte order.
+   *
+   * @param channel the FileChannel
+   * @param offset the starting index
+   * @param length the number of elements to write
+   * @return the number of bytes written
+   * @throws Exception if trouble
+   */
+  @Override
+  public long writeToChannel(final FileChannel channel, final int offset, final int length) throws Exception {
+    if (channel == null) {
+      throw new IllegalArgumentException(String2.ERROR + " in CharArray.writeToChannel: FileChannel is null.");
+    }
+    if (offset < 0) {
+      throw new IllegalArgumentException(
+          String2.ERROR + " in CharArray.writeToChannel: offset (" + offset + ") < 0.");
+    }
+    if (length < 0) {
+      throw new IllegalArgumentException(
+          String2.ERROR + " in CharArray.writeToChannel: length (" + length + ") < 0.");
+    }
+    if (offset + (long) length > size) {
+      throw new IllegalArgumentException(
+          String2.ERROR
+              + " in CharArray.writeToChannel: offset + length ("
+              + (offset + (long) length)
+              + ") > size ("
+              + size
+              + ").");
+    }
+    if (length == 0) {
+      return 0L;
+    }
+    final int bytesPerElement = 2;
+    final int byteSize = length * bytesPerElement;
+    final ByteBuffer byteBuf = ByteBuffer.allocate(byteSize).order(ByteOrder.nativeOrder());
+    byteBuf.asCharBuffer().put(array, offset, length);
+    byteBuf.position(0);
+    byteBuf.limit(byteSize);
+    long totalBytesWritten = 0;
+    while (byteBuf.hasRemaining()) {
+      final int written = channel.write(byteBuf);
+      if (written == 0) {
+        Thread.sleep(1);
+      }
+      totalBytesWritten += written;
+    }
+    return totalBytesWritten;
+  }
+
+  /**
+   * This reads/adds n elements from a FileChannel using native byte order.
+   *
+   * @param channel the FileChannel
+   * @param n the number of elements to read
+   * @throws Exception if trouble
+   */
+  @Override
+  public void readFromChannel(final FileChannel channel, final int n) throws Exception {
+    if (channel == null) {
+      throw new IllegalArgumentException(String2.ERROR + " in CharArray.readFromChannel: FileChannel is null.");
+    }
+    if (n < 0) {
+      throw new IllegalArgumentException(
+          String2.ERROR + " in CharArray.readFromChannel: n (" + n + ") < 0.");
+    }
+    if (n == 0) {
+      return;
+    }
+    ensureCapacity(size + (long) n);
+    final int bytesPerElement = 2;
+    final int bytesToRead = n * bytesPerElement;
+    final ByteBuffer byteBuf = ByteBuffer.allocate(bytesToRead).order(ByteOrder.nativeOrder());
+    int totalBytesRead = 0;
+    while (totalBytesRead < bytesToRead) {
+      final int read = channel.read(byteBuf);
+      if (read == -1) {
+        throw new EOFException(
+            String2.ERROR
+                + " in CharArray.readFromChannel: EOF reached after reading "
+                + totalBytesRead
+                + " of "
+                + bytesToRead
+                + " bytes.");
+      }
+      totalBytesRead += read;
+    }
+    byteBuf.position(0);
+    byteBuf.limit(bytesToRead);
+    byteBuf.asCharBuffer().get(array, size, n);
+    size += n;
   }
 
   /**

--- a/WEB-INF/classes/com/cohort/array/DoubleArray.java
+++ b/WEB-INF/classes/com/cohort/array/DoubleArray.java
@@ -11,6 +11,10 @@ import com.cohort.util.String2;
 import com.google.common.collect.ImmutableList;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
+import java.io.EOFException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.math.BigDecimal;
@@ -1086,6 +1090,112 @@ public class DoubleArray extends PrimitiveArray {
     for (int i = 0; i < size; i++)
       // this probably fails for some values since not all bit combos are valid doubles
       array[i] = Double.longBitsToDouble(Long.reverseBytes(Double.doubleToLongBits(array[i])));
+  }
+
+  /**
+   * This writes the active elements (0 ... size-1) to a FileChannel using native byte order.
+   *
+   * @param channel the FileChannel
+   * @return the number of bytes written
+   * @throws Exception if trouble
+   */
+  @Override
+  public long writeToChannel(final FileChannel channel) throws Exception {
+    return writeToChannel(channel, 0, size);
+  }
+
+  /**
+   * This writes a subset of elements (offset ... offset+length-1) to a FileChannel using native byte order.
+   *
+   * @param channel the FileChannel
+   * @param offset the starting index
+   * @param length the number of elements to write
+   * @return the number of bytes written
+   * @throws Exception if trouble
+   */
+  @Override
+  public long writeToChannel(final FileChannel channel, final int offset, final int length) throws Exception {
+    if (channel == null) {
+      throw new IllegalArgumentException(String2.ERROR + " in DoubleArray.writeToChannel: FileChannel is null.");
+    }
+    if (offset < 0) {
+      throw new IllegalArgumentException(
+          String2.ERROR + " in DoubleArray.writeToChannel: offset (" + offset + ") < 0.");
+    }
+    if (length < 0) {
+      throw new IllegalArgumentException(
+          String2.ERROR + " in DoubleArray.writeToChannel: length (" + length + ") < 0.");
+    }
+    if (offset + (long) length > size) {
+      throw new IllegalArgumentException(
+          String2.ERROR
+              + " in DoubleArray.writeToChannel: offset + length ("
+              + (offset + (long) length)
+              + ") > size ("
+              + size
+              + ").");
+    }
+    if (length == 0) {
+      return 0L;
+    }
+    final int bytesPerElement = 8;
+    final int byteSize = length * bytesPerElement;
+    final ByteBuffer byteBuf = ByteBuffer.allocate(byteSize).order(ByteOrder.nativeOrder());
+    byteBuf.asDoubleBuffer().put(array, offset, length);
+    byteBuf.position(0);
+    byteBuf.limit(byteSize);
+    long totalBytesWritten = 0;
+    while (byteBuf.hasRemaining()) {
+      final int written = channel.write(byteBuf);
+      if (written == 0) {
+        Thread.sleep(1);
+      }
+      totalBytesWritten += written;
+    }
+    return totalBytesWritten;
+  }
+
+  /**
+   * This reads/adds n elements from a FileChannel using native byte order.
+   *
+   * @param channel the FileChannel
+   * @param n the number of elements to read
+   * @throws Exception if trouble
+   */
+  @Override
+  public void readFromChannel(final FileChannel channel, final int n) throws Exception {
+    if (channel == null) {
+      throw new IllegalArgumentException(String2.ERROR + " in DoubleArray.readFromChannel: FileChannel is null.");
+    }
+    if (n < 0) {
+      throw new IllegalArgumentException(
+          String2.ERROR + " in DoubleArray.readFromChannel: n (" + n + ") < 0.");
+    }
+    if (n == 0) {
+      return;
+    }
+    ensureCapacity(size + (long) n);
+    final int bytesPerElement = 8;
+    final int bytesToRead = n * bytesPerElement;
+    final ByteBuffer byteBuf = ByteBuffer.allocate(bytesToRead).order(ByteOrder.nativeOrder());
+    int totalBytesRead = 0;
+    while (totalBytesRead < bytesToRead) {
+      final int read = channel.read(byteBuf);
+      if (read == -1) {
+        throw new EOFException(
+            String2.ERROR
+                + " in DoubleArray.readFromChannel: EOF reached after reading "
+                + totalBytesRead
+                + " of "
+                + bytesToRead
+                + " bytes.");
+      }
+      totalBytesRead += read;
+    }
+    byteBuf.position(0);
+    byteBuf.limit(bytesToRead);
+    byteBuf.asDoubleBuffer().get(array, size, n);
+    size += n;
   }
 
   /**

--- a/WEB-INF/classes/com/cohort/array/FloatArray.java
+++ b/WEB-INF/classes/com/cohort/array/FloatArray.java
@@ -9,6 +9,10 @@ import com.cohort.util.Math2;
 import com.cohort.util.String2;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
+import java.io.EOFException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.math.BigInteger;
@@ -1100,6 +1104,112 @@ public class FloatArray extends PrimitiveArray {
     for (int i = 0; i < size; i++)
       // this probably fails for some values since not all bit combos are valid floats
       array[i] = Float.intBitsToFloat(Integer.reverseBytes(Float.floatToIntBits(array[i])));
+  }
+
+  /**
+   * This writes the active elements (0 ... size-1) to a FileChannel using native byte order.
+   *
+   * @param channel the FileChannel
+   * @return the number of bytes written
+   * @throws Exception if trouble
+   */
+  @Override
+  public long writeToChannel(final FileChannel channel) throws Exception {
+    return writeToChannel(channel, 0, size);
+  }
+
+  /**
+   * This writes a subset of elements (offset ... offset+length-1) to a FileChannel using native byte order.
+   *
+   * @param channel the FileChannel
+   * @param offset the starting index
+   * @param length the number of elements to write
+   * @return the number of bytes written
+   * @throws Exception if trouble
+   */
+  @Override
+  public long writeToChannel(final FileChannel channel, final int offset, final int length) throws Exception {
+    if (channel == null) {
+      throw new IllegalArgumentException(String2.ERROR + " in FloatArray.writeToChannel: FileChannel is null.");
+    }
+    if (offset < 0) {
+      throw new IllegalArgumentException(
+          String2.ERROR + " in FloatArray.writeToChannel: offset (" + offset + ") < 0.");
+    }
+    if (length < 0) {
+      throw new IllegalArgumentException(
+          String2.ERROR + " in FloatArray.writeToChannel: length (" + length + ") < 0.");
+    }
+    if (offset + (long) length > size) {
+      throw new IllegalArgumentException(
+          String2.ERROR
+              + " in FloatArray.writeToChannel: offset + length ("
+              + (offset + (long) length)
+              + ") > size ("
+              + size
+              + ").");
+    }
+    if (length == 0) {
+      return 0L;
+    }
+    final int bytesPerElement = 4;
+    final int byteSize = length * bytesPerElement;
+    final ByteBuffer byteBuf = ByteBuffer.allocate(byteSize).order(ByteOrder.nativeOrder());
+    byteBuf.asFloatBuffer().put(array, offset, length);
+    byteBuf.position(0);
+    byteBuf.limit(byteSize);
+    long totalBytesWritten = 0;
+    while (byteBuf.hasRemaining()) {
+      final int written = channel.write(byteBuf);
+      if (written == 0) {
+        Thread.sleep(1);
+      }
+      totalBytesWritten += written;
+    }
+    return totalBytesWritten;
+  }
+
+  /**
+   * This reads/adds n elements from a FileChannel using native byte order.
+   *
+   * @param channel the FileChannel
+   * @param n the number of elements to read
+   * @throws Exception if trouble
+   */
+  @Override
+  public void readFromChannel(final FileChannel channel, final int n) throws Exception {
+    if (channel == null) {
+      throw new IllegalArgumentException(String2.ERROR + " in FloatArray.readFromChannel: FileChannel is null.");
+    }
+    if (n < 0) {
+      throw new IllegalArgumentException(
+          String2.ERROR + " in FloatArray.readFromChannel: n (" + n + ") < 0.");
+    }
+    if (n == 0) {
+      return;
+    }
+    ensureCapacity(size + (long) n);
+    final int bytesPerElement = 4;
+    final int bytesToRead = n * bytesPerElement;
+    final ByteBuffer byteBuf = ByteBuffer.allocate(bytesToRead).order(ByteOrder.nativeOrder());
+    int totalBytesRead = 0;
+    while (totalBytesRead < bytesToRead) {
+      final int read = channel.read(byteBuf);
+      if (read == -1) {
+        throw new EOFException(
+            String2.ERROR
+                + " in FloatArray.readFromChannel: EOF reached after reading "
+                + totalBytesRead
+                + " of "
+                + bytesToRead
+                + " bytes.");
+      }
+      totalBytesRead += read;
+    }
+    byteBuf.position(0);
+    byteBuf.limit(bytesToRead);
+    byteBuf.asFloatBuffer().get(array, size, n);
+    size += n;
   }
 
   /**

--- a/WEB-INF/classes/com/cohort/array/IntArray.java
+++ b/WEB-INF/classes/com/cohort/array/IntArray.java
@@ -9,6 +9,10 @@ import com.cohort.util.Math2;
 import com.cohort.util.String2;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
+import java.io.EOFException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.math.BigInteger;
@@ -1207,6 +1211,112 @@ public class IntArray extends PrimitiveArray {
   @Override
   public void reverseBytes() {
     for (int i = 0; i < size; i++) array[i] = Integer.reverseBytes(array[i]);
+  }
+
+  /**
+   * This writes the active elements (0 ... size-1) to a FileChannel using native byte order.
+   *
+   * @param channel the FileChannel
+   * @return the number of bytes written
+   * @throws Exception if trouble
+   */
+  @Override
+  public long writeToChannel(final FileChannel channel) throws Exception {
+    return writeToChannel(channel, 0, size);
+  }
+
+  /**
+   * This writes a subset of elements (offset ... offset+length-1) to a FileChannel using native byte order.
+   *
+   * @param channel the FileChannel
+   * @param offset the starting index
+   * @param length the number of elements to write
+   * @return the number of bytes written
+   * @throws Exception if trouble
+   */
+  @Override
+  public long writeToChannel(final FileChannel channel, final int offset, final int length) throws Exception {
+    if (channel == null) {
+      throw new IllegalArgumentException(String2.ERROR + " in IntArray.writeToChannel: FileChannel is null.");
+    }
+    if (offset < 0) {
+      throw new IllegalArgumentException(
+          String2.ERROR + " in IntArray.writeToChannel: offset (" + offset + ") < 0.");
+    }
+    if (length < 0) {
+      throw new IllegalArgumentException(
+          String2.ERROR + " in IntArray.writeToChannel: length (" + length + ") < 0.");
+    }
+    if (offset + (long) length > size) {
+      throw new IllegalArgumentException(
+          String2.ERROR
+              + " in IntArray.writeToChannel: offset + length ("
+              + (offset + (long) length)
+              + ") > size ("
+              + size
+              + ").");
+    }
+    if (length == 0) {
+      return 0L;
+    }
+    final int bytesPerElement = 4;
+    final int byteSize = length * bytesPerElement;
+    final ByteBuffer byteBuf = ByteBuffer.allocate(byteSize).order(ByteOrder.nativeOrder());
+    byteBuf.asIntBuffer().put(array, offset, length);
+    byteBuf.position(0);
+    byteBuf.limit(byteSize);
+    long totalBytesWritten = 0;
+    while (byteBuf.hasRemaining()) {
+      final int written = channel.write(byteBuf);
+      if (written == 0) {
+        Thread.sleep(1);
+      }
+      totalBytesWritten += written;
+    }
+    return totalBytesWritten;
+  }
+
+  /**
+   * This reads/adds n elements from a FileChannel using native byte order.
+   *
+   * @param channel the FileChannel
+   * @param n the number of elements to read
+   * @throws Exception if trouble
+   */
+  @Override
+  public void readFromChannel(final FileChannel channel, final int n) throws Exception {
+    if (channel == null) {
+      throw new IllegalArgumentException(String2.ERROR + " in IntArray.readFromChannel: FileChannel is null.");
+    }
+    if (n < 0) {
+      throw new IllegalArgumentException(
+          String2.ERROR + " in IntArray.readFromChannel: n (" + n + ") < 0.");
+    }
+    if (n == 0) {
+      return;
+    }
+    ensureCapacity(size + (long) n);
+    final int bytesPerElement = 4;
+    final int bytesToRead = n * bytesPerElement;
+    final ByteBuffer byteBuf = ByteBuffer.allocate(bytesToRead).order(ByteOrder.nativeOrder());
+    int totalBytesRead = 0;
+    while (totalBytesRead < bytesToRead) {
+      final int read = channel.read(byteBuf);
+      if (read == -1) {
+        throw new EOFException(
+            String2.ERROR
+                + " in IntArray.readFromChannel: EOF reached after reading "
+                + totalBytesRead
+                + " of "
+                + bytesToRead
+                + " bytes.");
+      }
+      totalBytesRead += read;
+    }
+    byteBuf.position(0);
+    byteBuf.limit(bytesToRead);
+    byteBuf.asIntBuffer().get(array, size, n);
+    size += n;
   }
 
   /**

--- a/WEB-INF/classes/com/cohort/array/LongArray.java
+++ b/WEB-INF/classes/com/cohort/array/LongArray.java
@@ -9,6 +9,10 @@ import com.cohort.util.Math2;
 import com.cohort.util.String2;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
+import java.io.EOFException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.math.BigInteger;
@@ -1166,6 +1170,112 @@ public class LongArray extends PrimitiveArray {
   @Override
   public void reverseBytes() {
     for (int i = 0; i < size; i++) array[i] = Long.reverseBytes(array[i]);
+  }
+
+  /**
+   * This writes the active elements (0 ... size-1) to a FileChannel using native byte order.
+   *
+   * @param channel the FileChannel
+   * @return the number of bytes written
+   * @throws Exception if trouble
+   */
+  @Override
+  public long writeToChannel(final FileChannel channel) throws Exception {
+    return writeToChannel(channel, 0, size);
+  }
+
+  /**
+   * This writes a subset of elements (offset ... offset+length-1) to a FileChannel using native byte order.
+   *
+   * @param channel the FileChannel
+   * @param offset the starting index
+   * @param length the number of elements to write
+   * @return the number of bytes written
+   * @throws Exception if trouble
+   */
+  @Override
+  public long writeToChannel(final FileChannel channel, final int offset, final int length) throws Exception {
+    if (channel == null) {
+      throw new IllegalArgumentException(String2.ERROR + " in LongArray.writeToChannel: FileChannel is null.");
+    }
+    if (offset < 0) {
+      throw new IllegalArgumentException(
+          String2.ERROR + " in LongArray.writeToChannel: offset (" + offset + ") < 0.");
+    }
+    if (length < 0) {
+      throw new IllegalArgumentException(
+          String2.ERROR + " in LongArray.writeToChannel: length (" + length + ") < 0.");
+    }
+    if (offset + (long) length > size) {
+      throw new IllegalArgumentException(
+          String2.ERROR
+              + " in LongArray.writeToChannel: offset + length ("
+              + (offset + (long) length)
+              + ") > size ("
+              + size
+              + ").");
+    }
+    if (length == 0) {
+      return 0L;
+    }
+    final int bytesPerElement = 8;
+    final int byteSize = length * bytesPerElement;
+    final ByteBuffer byteBuf = ByteBuffer.allocate(byteSize).order(ByteOrder.nativeOrder());
+    byteBuf.asLongBuffer().put(array, offset, length);
+    byteBuf.position(0);
+    byteBuf.limit(byteSize);
+    long totalBytesWritten = 0;
+    while (byteBuf.hasRemaining()) {
+      final int written = channel.write(byteBuf);
+      if (written == 0) {
+        Thread.sleep(1);
+      }
+      totalBytesWritten += written;
+    }
+    return totalBytesWritten;
+  }
+
+  /**
+   * This reads/adds n elements from a FileChannel using native byte order.
+   *
+   * @param channel the FileChannel
+   * @param n the number of elements to read
+   * @throws Exception if trouble
+   */
+  @Override
+  public void readFromChannel(final FileChannel channel, final int n) throws Exception {
+    if (channel == null) {
+      throw new IllegalArgumentException(String2.ERROR + " in LongArray.readFromChannel: FileChannel is null.");
+    }
+    if (n < 0) {
+      throw new IllegalArgumentException(
+          String2.ERROR + " in LongArray.readFromChannel: n (" + n + ") < 0.");
+    }
+    if (n == 0) {
+      return;
+    }
+    ensureCapacity(size + (long) n);
+    final int bytesPerElement = 8;
+    final int bytesToRead = n * bytesPerElement;
+    final ByteBuffer byteBuf = ByteBuffer.allocate(bytesToRead).order(ByteOrder.nativeOrder());
+    int totalBytesRead = 0;
+    while (totalBytesRead < bytesToRead) {
+      final int read = channel.read(byteBuf);
+      if (read == -1) {
+        throw new EOFException(
+            String2.ERROR
+                + " in LongArray.readFromChannel: EOF reached after reading "
+                + totalBytesRead
+                + " of "
+                + bytesToRead
+                + " bytes.");
+      }
+      totalBytesRead += read;
+    }
+    byteBuf.position(0);
+    byteBuf.limit(bytesToRead);
+    byteBuf.asLongBuffer().get(array, size, n);
+    size += n;
   }
 
   /**

--- a/WEB-INF/classes/com/cohort/array/PrimitiveArray.java
+++ b/WEB-INF/classes/com/cohort/array/PrimitiveArray.java
@@ -10,6 +10,7 @@ import com.cohort.util.SimpleException;
 import com.cohort.util.String2;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
+import java.nio.channels.FileChannel;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.math.BigInteger;
@@ -1765,6 +1766,35 @@ public abstract class PrimitiveArray {
    * little-endian source.
    */
   public abstract void reverseBytes();
+
+  /**
+   * This writes the active elements (0 ... size-1) to a FileChannel using native byte order.
+   *
+   * @param channel the FileChannel
+   * @return the number of bytes written
+   * @throws Exception if trouble
+   */
+  public abstract long writeToChannel(FileChannel channel) throws Exception;
+
+  /**
+   * This writes a subset of elements (offset ... offset+length-1) to a FileChannel using native byte order.
+   *
+   * @param channel the FileChannel
+   * @param offset the starting index
+   * @param length the number of elements to write
+   * @return the number of bytes written
+   * @throws Exception if trouble
+   */
+  public abstract long writeToChannel(FileChannel channel, int offset, int length) throws Exception;
+
+  /**
+   * This reads/adds n elements from a FileChannel using native byte order.
+   *
+   * @param channel the FileChannel
+   * @param n the number of elements to read
+   * @throws Exception if trouble
+   */
+  public abstract void readFromChannel(FileChannel channel, int n) throws Exception;
 
   /**
    * This writes 'size' elements to a DataOutputStream.

--- a/WEB-INF/classes/com/cohort/array/PrimitiveArray.java
+++ b/WEB-INF/classes/com/cohort/array/PrimitiveArray.java
@@ -1769,6 +1769,7 @@ public abstract class PrimitiveArray {
 
   /**
    * This writes the active elements (0 ... size-1) to a FileChannel using native byte order.
+   * Note: This method modifies the FileChannel's current position.
    *
    * @param channel the FileChannel
    * @return the number of bytes written
@@ -1778,6 +1779,7 @@ public abstract class PrimitiveArray {
 
   /**
    * This writes a subset of elements (offset ... offset+length-1) to a FileChannel using native byte order.
+   * Note: This method modifies the FileChannel's current position.
    *
    * @param channel the FileChannel
    * @param offset the starting index
@@ -1789,10 +1791,12 @@ public abstract class PrimitiveArray {
 
   /**
    * This reads/adds n elements from a FileChannel using native byte order.
+   * Note: This method modifies the FileChannel's current position.
    *
    * @param channel the FileChannel
    * @param n the number of elements to read
-   * @throws Exception if trouble
+   * @throws java.io.EOFException if EOF is reached before n elements are fully read
+   * @throws Exception if other trouble
    */
   public abstract void readFromChannel(FileChannel channel, int n) throws Exception;
 

--- a/WEB-INF/classes/com/cohort/array/ShortArray.java
+++ b/WEB-INF/classes/com/cohort/array/ShortArray.java
@@ -9,6 +9,10 @@ import com.cohort.util.Math2;
 import com.cohort.util.String2;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
+import java.io.EOFException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.math.BigInteger;
@@ -1231,6 +1235,112 @@ public class ShortArray extends PrimitiveArray {
   @Override
   public void reverseBytes() {
     for (int i = 0; i < size; i++) array[i] = Short.reverseBytes(array[i]);
+  }
+
+  /**
+   * This writes the active elements (0 ... size-1) to a FileChannel using native byte order.
+   *
+   * @param channel the FileChannel
+   * @return the number of bytes written
+   * @throws Exception if trouble
+   */
+  @Override
+  public long writeToChannel(final FileChannel channel) throws Exception {
+    return writeToChannel(channel, 0, size);
+  }
+
+  /**
+   * This writes a subset of elements (offset ... offset+length-1) to a FileChannel using native byte order.
+   *
+   * @param channel the FileChannel
+   * @param offset the starting index
+   * @param length the number of elements to write
+   * @return the number of bytes written
+   * @throws Exception if trouble
+   */
+  @Override
+  public long writeToChannel(final FileChannel channel, final int offset, final int length) throws Exception {
+    if (channel == null) {
+      throw new IllegalArgumentException(String2.ERROR + " in ShortArray.writeToChannel: FileChannel is null.");
+    }
+    if (offset < 0) {
+      throw new IllegalArgumentException(
+          String2.ERROR + " in ShortArray.writeToChannel: offset (" + offset + ") < 0.");
+    }
+    if (length < 0) {
+      throw new IllegalArgumentException(
+          String2.ERROR + " in ShortArray.writeToChannel: length (" + length + ") < 0.");
+    }
+    if (offset + (long) length > size) {
+      throw new IllegalArgumentException(
+          String2.ERROR
+              + " in ShortArray.writeToChannel: offset + length ("
+              + (offset + (long) length)
+              + ") > size ("
+              + size
+              + ").");
+    }
+    if (length == 0) {
+      return 0L;
+    }
+    final int bytesPerElement = 2;
+    final int byteSize = length * bytesPerElement;
+    final ByteBuffer byteBuf = ByteBuffer.allocate(byteSize).order(ByteOrder.nativeOrder());
+    byteBuf.asShortBuffer().put(array, offset, length);
+    byteBuf.position(0);
+    byteBuf.limit(byteSize);
+    long totalBytesWritten = 0;
+    while (byteBuf.hasRemaining()) {
+      final int written = channel.write(byteBuf);
+      if (written == 0) {
+        Thread.sleep(1);
+      }
+      totalBytesWritten += written;
+    }
+    return totalBytesWritten;
+  }
+
+  /**
+   * This reads/adds n elements from a FileChannel using native byte order.
+   *
+   * @param channel the FileChannel
+   * @param n the number of elements to read
+   * @throws Exception if trouble
+   */
+  @Override
+  public void readFromChannel(final FileChannel channel, final int n) throws Exception {
+    if (channel == null) {
+      throw new IllegalArgumentException(String2.ERROR + " in ShortArray.readFromChannel: FileChannel is null.");
+    }
+    if (n < 0) {
+      throw new IllegalArgumentException(
+          String2.ERROR + " in ShortArray.readFromChannel: n (" + n + ") < 0.");
+    }
+    if (n == 0) {
+      return;
+    }
+    ensureCapacity(size + (long) n);
+    final int bytesPerElement = 2;
+    final int bytesToRead = n * bytesPerElement;
+    final ByteBuffer byteBuf = ByteBuffer.allocate(bytesToRead).order(ByteOrder.nativeOrder());
+    int totalBytesRead = 0;
+    while (totalBytesRead < bytesToRead) {
+      final int read = channel.read(byteBuf);
+      if (read == -1) {
+        throw new EOFException(
+            String2.ERROR
+                + " in ShortArray.readFromChannel: EOF reached after reading "
+                + totalBytesRead
+                + " of "
+                + bytesToRead
+                + " bytes.");
+      }
+      totalBytesRead += read;
+    }
+    byteBuf.position(0);
+    byteBuf.limit(bytesToRead);
+    byteBuf.asShortBuffer().get(array, size, n);
+    size += n;
   }
 
   /**

--- a/WEB-INF/classes/com/cohort/array/StringArray.java
+++ b/WEB-INF/classes/com/cohort/array/StringArray.java
@@ -13,6 +13,9 @@ import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
+import java.io.EOFException;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.RandomAccessFile;
@@ -1578,6 +1581,87 @@ public class StringArray extends PrimitiveArray {
   @Override
   public void reverseBytes() {
     // StringArray does nothing because insensitive to big/little-endian
+  }
+
+  /**
+   * This writes the active elements (0 ... size-1) to a FileChannel using native byte order.
+   *
+   * @param channel the FileChannel
+   * @return the number of bytes written
+   * @throws Exception if trouble
+   */
+  @Override
+  public long writeToChannel(final FileChannel channel) throws Exception {
+    return writeToChannel(channel, 0, size);
+  }
+
+  /**
+   * This writes a subset of elements (offset ... offset+length-1) to a FileChannel using native byte order.
+   *
+   * @param channel the FileChannel
+   * @param offset the starting index
+   * @param length the number of elements to write
+   * @return the number of bytes written
+   * @throws Exception if trouble
+   */
+  @Override
+  public long writeToChannel(final FileChannel channel, final int offset, final int length) throws Exception {
+    if (channel == null) {
+      throw new IllegalArgumentException(String2.ERROR + " in StringArray.writeToChannel: FileChannel is null.");
+    }
+    if (offset < 0) {
+      throw new IllegalArgumentException(
+          String2.ERROR + " in StringArray.writeToChannel: offset (" + offset + ") < 0.");
+    }
+    if (length < 0) {
+      throw new IllegalArgumentException(
+          String2.ERROR + " in StringArray.writeToChannel: length (" + length + ") < 0.");
+    }
+    if (offset + (long) length > size) {
+      throw new IllegalArgumentException(
+          String2.ERROR
+              + " in StringArray.writeToChannel: offset + length ("
+              + (offset + (long) length)
+              + ") > size ("
+              + size
+              + ").");
+    }
+    if (length == 0) {
+      return 0L;
+    }
+    final long startPos = channel.position();
+    final DataOutputStream dos = new DataOutputStream(Channels.newOutputStream(channel));
+    for (int i = offset; i < offset + length; i++) {
+      dos.writeUTF(get(i));
+    }
+    dos.flush();
+    return channel.position() - startPos;
+  }
+
+  /**
+   * This reads/adds n elements from a FileChannel using native byte order.
+   *
+   * @param channel the FileChannel
+   * @param n the number of elements to read
+   * @throws Exception if trouble
+   */
+  @Override
+  public void readFromChannel(final FileChannel channel, final int n) throws Exception {
+    if (channel == null) {
+      throw new IllegalArgumentException(String2.ERROR + " in StringArray.readFromChannel: FileChannel is null.");
+    }
+    if (n < 0) {
+      throw new IllegalArgumentException(
+          String2.ERROR + " in StringArray.readFromChannel: n (" + n + ") < 0.");
+    }
+    if (n == 0) {
+      return;
+    }
+    ensureCapacity(size + (long) n);
+    final DataInputStream dis = new DataInputStream(Channels.newInputStream(channel));
+    for (int i = 0; i < n; i++) {
+      add(dis.readUTF());
+    }
   }
 
   /**

--- a/WEB-INF/classes/com/cohort/array/UByteArray.java
+++ b/WEB-INF/classes/com/cohort/array/UByteArray.java
@@ -10,6 +10,10 @@ import com.cohort.util.Math2;
 import com.cohort.util.String2;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
+import java.io.EOFException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.RandomAccessFile;
@@ -1412,6 +1416,106 @@ public class UByteArray extends PrimitiveArray {
   @Override
   public void reverseBytes() {
     // UByteArray does nothing
+  }
+
+  /**
+   * This writes the active elements (0 ... size-1) to a FileChannel using native byte order.
+   *
+   * @param channel the FileChannel
+   * @return the number of bytes written
+   * @throws Exception if trouble
+   */
+  @Override
+  public long writeToChannel(final FileChannel channel) throws Exception {
+    return writeToChannel(channel, 0, size);
+  }
+
+  /**
+   * This writes a subset of elements (offset ... offset+length-1) to a FileChannel using native byte order.
+   *
+   * @param channel the FileChannel
+   * @param offset the starting index
+   * @param length the number of elements to write
+   * @return the number of bytes written
+   * @throws Exception if trouble
+   */
+  @Override
+  public long writeToChannel(final FileChannel channel, final int offset, final int length) throws Exception {
+    if (channel == null) {
+      throw new IllegalArgumentException(String2.ERROR + " in UByteArray.writeToChannel: FileChannel is null.");
+    }
+    if (offset < 0) {
+      throw new IllegalArgumentException(
+          String2.ERROR + " in UByteArray.writeToChannel: offset (" + offset + ") < 0.");
+    }
+    if (length < 0) {
+      throw new IllegalArgumentException(
+          String2.ERROR + " in UByteArray.writeToChannel: length (" + length + ") < 0.");
+    }
+    if (offset + (long) length > size) {
+      throw new IllegalArgumentException(
+          String2.ERROR
+              + " in UByteArray.writeToChannel: offset + length ("
+              + (offset + (long) length)
+              + ") > size ("
+              + size
+              + ").");
+    }
+    if (length == 0) {
+      return 0L;
+    }
+    final int bytesPerElement = 1;
+    final int byteSize = length * bytesPerElement;
+    final ByteBuffer byteBuf = ByteBuffer.wrap(array, offset, length).order(ByteOrder.nativeOrder());
+    long totalBytesWritten = 0;
+    while (byteBuf.hasRemaining()) {
+      final int written = channel.write(byteBuf);
+      if (written == 0) {
+        Thread.sleep(1);
+      }
+      totalBytesWritten += written;
+    }
+    return totalBytesWritten;
+  }
+
+  /**
+   * This reads/adds n elements from a FileChannel using native byte order.
+   *
+   * @param channel the FileChannel
+   * @param n the number of elements to read
+   * @throws Exception if trouble
+   */
+  @Override
+  public void readFromChannel(final FileChannel channel, final int n) throws Exception {
+    if (channel == null) {
+      throw new IllegalArgumentException(String2.ERROR + " in UByteArray.readFromChannel: FileChannel is null.");
+    }
+    if (n < 0) {
+      throw new IllegalArgumentException(
+          String2.ERROR + " in UByteArray.readFromChannel: n (" + n + ") < 0.");
+    }
+    if (n == 0) {
+      return;
+    }
+    ensureCapacity(size + (long) n);
+    final int bytesPerElement = 1;
+    final int bytesToRead = n * bytesPerElement;
+    final ByteBuffer byteBuf = ByteBuffer.wrap(array, size, n).order(ByteOrder.nativeOrder());
+    int totalBytesRead = 0;
+    while (totalBytesRead < bytesToRead) {
+      final int read = channel.read(byteBuf);
+      if (read == -1) {
+        throw new EOFException(
+            String2.ERROR
+                + " in UByteArray.readFromChannel: EOF reached after reading "
+                + totalBytesRead
+                + " of "
+                + bytesToRead
+                + " bytes.");
+      }
+      totalBytesRead += read;
+    }
+    size += n;
   }
 
   /**

--- a/WEB-INF/classes/com/cohort/array/UIntArray.java
+++ b/WEB-INF/classes/com/cohort/array/UIntArray.java
@@ -9,6 +9,10 @@ import com.cohort.util.Math2;
 import com.cohort.util.String2;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
+import java.io.EOFException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.math.BigInteger;
@@ -1287,6 +1291,112 @@ public class UIntArray extends PrimitiveArray {
   @Override
   public void reverseBytes() {
     for (int i = 0; i < size; i++) array[i] = Integer.reverseBytes(array[i]);
+  }
+
+  /**
+   * This writes the active elements (0 ... size-1) to a FileChannel using native byte order.
+   *
+   * @param channel the FileChannel
+   * @return the number of bytes written
+   * @throws Exception if trouble
+   */
+  @Override
+  public long writeToChannel(final FileChannel channel) throws Exception {
+    return writeToChannel(channel, 0, size);
+  }
+
+  /**
+   * This writes a subset of elements (offset ... offset+length-1) to a FileChannel using native byte order.
+   *
+   * @param channel the FileChannel
+   * @param offset the starting index
+   * @param length the number of elements to write
+   * @return the number of bytes written
+   * @throws Exception if trouble
+   */
+  @Override
+  public long writeToChannel(final FileChannel channel, final int offset, final int length) throws Exception {
+    if (channel == null) {
+      throw new IllegalArgumentException(String2.ERROR + " in UIntArray.writeToChannel: FileChannel is null.");
+    }
+    if (offset < 0) {
+      throw new IllegalArgumentException(
+          String2.ERROR + " in UIntArray.writeToChannel: offset (" + offset + ") < 0.");
+    }
+    if (length < 0) {
+      throw new IllegalArgumentException(
+          String2.ERROR + " in UIntArray.writeToChannel: length (" + length + ") < 0.");
+    }
+    if (offset + (long) length > size) {
+      throw new IllegalArgumentException(
+          String2.ERROR
+              + " in UIntArray.writeToChannel: offset + length ("
+              + (offset + (long) length)
+              + ") > size ("
+              + size
+              + ").");
+    }
+    if (length == 0) {
+      return 0L;
+    }
+    final int bytesPerElement = 4;
+    final int byteSize = length * bytesPerElement;
+    final ByteBuffer byteBuf = ByteBuffer.allocate(byteSize).order(ByteOrder.nativeOrder());
+    byteBuf.asIntBuffer().put(array, offset, length);
+    byteBuf.position(0);
+    byteBuf.limit(byteSize);
+    long totalBytesWritten = 0;
+    while (byteBuf.hasRemaining()) {
+      final int written = channel.write(byteBuf);
+      if (written == 0) {
+        Thread.sleep(1);
+      }
+      totalBytesWritten += written;
+    }
+    return totalBytesWritten;
+  }
+
+  /**
+   * This reads/adds n elements from a FileChannel using native byte order.
+   *
+   * @param channel the FileChannel
+   * @param n the number of elements to read
+   * @throws Exception if trouble
+   */
+  @Override
+  public void readFromChannel(final FileChannel channel, final int n) throws Exception {
+    if (channel == null) {
+      throw new IllegalArgumentException(String2.ERROR + " in UIntArray.readFromChannel: FileChannel is null.");
+    }
+    if (n < 0) {
+      throw new IllegalArgumentException(
+          String2.ERROR + " in UIntArray.readFromChannel: n (" + n + ") < 0.");
+    }
+    if (n == 0) {
+      return;
+    }
+    ensureCapacity(size + (long) n);
+    final int bytesPerElement = 4;
+    final int bytesToRead = n * bytesPerElement;
+    final ByteBuffer byteBuf = ByteBuffer.allocate(bytesToRead).order(ByteOrder.nativeOrder());
+    int totalBytesRead = 0;
+    while (totalBytesRead < bytesToRead) {
+      final int read = channel.read(byteBuf);
+      if (read == -1) {
+        throw new EOFException(
+            String2.ERROR
+                + " in UIntArray.readFromChannel: EOF reached after reading "
+                + totalBytesRead
+                + " of "
+                + bytesToRead
+                + " bytes.");
+      }
+      totalBytesRead += read;
+    }
+    byteBuf.position(0);
+    byteBuf.limit(bytesToRead);
+    byteBuf.asIntBuffer().get(array, size, n);
+    size += n;
   }
 
   /**

--- a/WEB-INF/classes/com/cohort/array/ULongArray.java
+++ b/WEB-INF/classes/com/cohort/array/ULongArray.java
@@ -9,6 +9,10 @@ import com.cohort.util.Math2;
 import com.cohort.util.String2;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
+import java.io.EOFException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.math.BigInteger;
@@ -1318,6 +1322,112 @@ public class ULongArray extends PrimitiveArray {
   @Override
   public void reverseBytes() {
     for (int i = 0; i < size; i++) array[i] = Long.reverseBytes(array[i]);
+  }
+
+  /**
+   * This writes the active elements (0 ... size-1) to a FileChannel using native byte order.
+   *
+   * @param channel the FileChannel
+   * @return the number of bytes written
+   * @throws Exception if trouble
+   */
+  @Override
+  public long writeToChannel(final FileChannel channel) throws Exception {
+    return writeToChannel(channel, 0, size);
+  }
+
+  /**
+   * This writes a subset of elements (offset ... offset+length-1) to a FileChannel using native byte order.
+   *
+   * @param channel the FileChannel
+   * @param offset the starting index
+   * @param length the number of elements to write
+   * @return the number of bytes written
+   * @throws Exception if trouble
+   */
+  @Override
+  public long writeToChannel(final FileChannel channel, final int offset, final int length) throws Exception {
+    if (channel == null) {
+      throw new IllegalArgumentException(String2.ERROR + " in ULongArray.writeToChannel: FileChannel is null.");
+    }
+    if (offset < 0) {
+      throw new IllegalArgumentException(
+          String2.ERROR + " in ULongArray.writeToChannel: offset (" + offset + ") < 0.");
+    }
+    if (length < 0) {
+      throw new IllegalArgumentException(
+          String2.ERROR + " in ULongArray.writeToChannel: length (" + length + ") < 0.");
+    }
+    if (offset + (long) length > size) {
+      throw new IllegalArgumentException(
+          String2.ERROR
+              + " in ULongArray.writeToChannel: offset + length ("
+              + (offset + (long) length)
+              + ") > size ("
+              + size
+              + ").");
+    }
+    if (length == 0) {
+      return 0L;
+    }
+    final int bytesPerElement = 8;
+    final int byteSize = length * bytesPerElement;
+    final ByteBuffer byteBuf = ByteBuffer.allocate(byteSize).order(ByteOrder.nativeOrder());
+    byteBuf.asLongBuffer().put(array, offset, length);
+    byteBuf.position(0);
+    byteBuf.limit(byteSize);
+    long totalBytesWritten = 0;
+    while (byteBuf.hasRemaining()) {
+      final int written = channel.write(byteBuf);
+      if (written == 0) {
+        Thread.sleep(1);
+      }
+      totalBytesWritten += written;
+    }
+    return totalBytesWritten;
+  }
+
+  /**
+   * This reads/adds n elements from a FileChannel using native byte order.
+   *
+   * @param channel the FileChannel
+   * @param n the number of elements to read
+   * @throws Exception if trouble
+   */
+  @Override
+  public void readFromChannel(final FileChannel channel, final int n) throws Exception {
+    if (channel == null) {
+      throw new IllegalArgumentException(String2.ERROR + " in ULongArray.readFromChannel: FileChannel is null.");
+    }
+    if (n < 0) {
+      throw new IllegalArgumentException(
+          String2.ERROR + " in ULongArray.readFromChannel: n (" + n + ") < 0.");
+    }
+    if (n == 0) {
+      return;
+    }
+    ensureCapacity(size + (long) n);
+    final int bytesPerElement = 8;
+    final int bytesToRead = n * bytesPerElement;
+    final ByteBuffer byteBuf = ByteBuffer.allocate(bytesToRead).order(ByteOrder.nativeOrder());
+    int totalBytesRead = 0;
+    while (totalBytesRead < bytesToRead) {
+      final int read = channel.read(byteBuf);
+      if (read == -1) {
+        throw new EOFException(
+            String2.ERROR
+                + " in ULongArray.readFromChannel: EOF reached after reading "
+                + totalBytesRead
+                + " of "
+                + bytesToRead
+                + " bytes.");
+      }
+      totalBytesRead += read;
+    }
+    byteBuf.position(0);
+    byteBuf.limit(bytesToRead);
+    byteBuf.asLongBuffer().get(array, size, n);
+    size += n;
   }
 
   /**

--- a/WEB-INF/classes/com/cohort/array/UShortArray.java
+++ b/WEB-INF/classes/com/cohort/array/UShortArray.java
@@ -9,6 +9,10 @@ import com.cohort.util.Math2;
 import com.cohort.util.String2;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
+import java.io.EOFException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.math.BigInteger;
@@ -1318,6 +1322,112 @@ public class UShortArray extends PrimitiveArray {
   @Override
   public void reverseBytes() {
     for (int i = 0; i < size; i++) array[i] = Short.reverseBytes(array[i]);
+  }
+
+  /**
+   * This writes the active elements (0 ... size-1) to a FileChannel using native byte order.
+   *
+   * @param channel the FileChannel
+   * @return the number of bytes written
+   * @throws Exception if trouble
+   */
+  @Override
+  public long writeToChannel(final FileChannel channel) throws Exception {
+    return writeToChannel(channel, 0, size);
+  }
+
+  /**
+   * This writes a subset of elements (offset ... offset+length-1) to a FileChannel using native byte order.
+   *
+   * @param channel the FileChannel
+   * @param offset the starting index
+   * @param length the number of elements to write
+   * @return the number of bytes written
+   * @throws Exception if trouble
+   */
+  @Override
+  public long writeToChannel(final FileChannel channel, final int offset, final int length) throws Exception {
+    if (channel == null) {
+      throw new IllegalArgumentException(String2.ERROR + " in UShortArray.writeToChannel: FileChannel is null.");
+    }
+    if (offset < 0) {
+      throw new IllegalArgumentException(
+          String2.ERROR + " in UShortArray.writeToChannel: offset (" + offset + ") < 0.");
+    }
+    if (length < 0) {
+      throw new IllegalArgumentException(
+          String2.ERROR + " in UShortArray.writeToChannel: length (" + length + ") < 0.");
+    }
+    if (offset + (long) length > size) {
+      throw new IllegalArgumentException(
+          String2.ERROR
+              + " in UShortArray.writeToChannel: offset + length ("
+              + (offset + (long) length)
+              + ") > size ("
+              + size
+              + ").");
+    }
+    if (length == 0) {
+      return 0L;
+    }
+    final int bytesPerElement = 2;
+    final int byteSize = length * bytesPerElement;
+    final ByteBuffer byteBuf = ByteBuffer.allocate(byteSize).order(ByteOrder.nativeOrder());
+    byteBuf.asShortBuffer().put(array, offset, length);
+    byteBuf.position(0);
+    byteBuf.limit(byteSize);
+    long totalBytesWritten = 0;
+    while (byteBuf.hasRemaining()) {
+      final int written = channel.write(byteBuf);
+      if (written == 0) {
+        Thread.sleep(1);
+      }
+      totalBytesWritten += written;
+    }
+    return totalBytesWritten;
+  }
+
+  /**
+   * This reads/adds n elements from a FileChannel using native byte order.
+   *
+   * @param channel the FileChannel
+   * @param n the number of elements to read
+   * @throws Exception if trouble
+   */
+  @Override
+  public void readFromChannel(final FileChannel channel, final int n) throws Exception {
+    if (channel == null) {
+      throw new IllegalArgumentException(String2.ERROR + " in UShortArray.readFromChannel: FileChannel is null.");
+    }
+    if (n < 0) {
+      throw new IllegalArgumentException(
+          String2.ERROR + " in UShortArray.readFromChannel: n (" + n + ") < 0.");
+    }
+    if (n == 0) {
+      return;
+    }
+    ensureCapacity(size + (long) n);
+    final int bytesPerElement = 2;
+    final int bytesToRead = n * bytesPerElement;
+    final ByteBuffer byteBuf = ByteBuffer.allocate(bytesToRead).order(ByteOrder.nativeOrder());
+    int totalBytesRead = 0;
+    while (totalBytesRead < bytesToRead) {
+      final int read = channel.read(byteBuf);
+      if (read == -1) {
+        throw new EOFException(
+            String2.ERROR
+                + " in UShortArray.readFromChannel: EOF reached after reading "
+                + totalBytesRead
+                + " of "
+                + bytesToRead
+                + " bytes.");
+      }
+      totalBytesRead += read;
+    }
+    byteBuf.position(0);
+    byteBuf.limit(bytesToRead);
+    byteBuf.asShortBuffer().get(array, size, n);
+    size += n;
   }
 
   /**

--- a/src/test/java/com/cohort/array/PrimitiveArrayTests.java
+++ b/src/test/java/com/cohort/array/PrimitiveArrayTests.java
@@ -368,6 +368,240 @@ class PrimitiveArrayTests {
     Test.ensureEqual(pa.toString(), "'a', ''", "");
   }
 
+  @org.junit.jupiter.api.Test
+  void testFileChannelBulkIO() throws Throwable {
+    String2.log("*** PrimitiveArray.testFileChannelBulkIO");
+    java.nio.file.Path tempFile = java.nio.file.Files.createTempFile("bulk_io_test", ".bin");
+    try {
+      // 1. DoubleArray test
+      {
+        DoubleArray original = new DoubleArray(new double[]{1.1, 2.2, 3.3, 4.4, 5.5});
+        try (java.nio.channels.FileChannel channel = java.nio.channels.FileChannel.open(tempFile,
+            java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.WRITE, java.nio.file.StandardOpenOption.READ)) {
+
+          // test writing full channel
+          long bytesWritten = original.writeToChannel(channel);
+          Test.ensureEqual(bytesWritten, 5L * 8L, "DoubleArray bytesWritten full");
+
+          // test writing subset
+          channel.position(0);
+          bytesWritten = original.writeToChannel(channel, 1, 3); // elements 2.2, 3.3, 4.4
+          Test.ensureEqual(bytesWritten, 3L * 8L, "DoubleArray bytesWritten subset");
+
+          // test writing 0 length
+          bytesWritten = original.writeToChannel(channel, 1, 0);
+          Test.ensureEqual(bytesWritten, 0L, "DoubleArray write 0 length");
+
+          // test read back
+          channel.position(0);
+          DoubleArray target = new DoubleArray();
+          target.readFromChannel(channel, 3);
+          Test.ensureEqual(target.size(), 3, "DoubleArray read size");
+          Test.ensureEqual(target.get(0), 2.2, "DoubleArray val 0");
+          Test.ensureEqual(target.get(1), 3.3, "DoubleArray val 1");
+          Test.ensureEqual(target.get(2), 4.4, "DoubleArray val 2");
+
+          // test reading 0 length
+          target.readFromChannel(channel, 0);
+          Test.ensureEqual(target.size(), 3, "DoubleArray read 0 length size");
+
+          // test bounds error
+          boolean failed = false;
+          try {
+            original.writeToChannel(channel, -1, 3);
+          } catch (IllegalArgumentException e) {
+            failed = true;
+          }
+          Test.ensureTrue(failed, "DoubleArray: should throw IllegalArgumentException for offset < 0");
+
+          failed = false;
+          try {
+            original.writeToChannel(channel, 1, -1);
+          } catch (IllegalArgumentException e) {
+            failed = true;
+          }
+          Test.ensureTrue(failed, "DoubleArray: should throw IllegalArgumentException for length < 0");
+
+          failed = false;
+          try {
+            original.writeToChannel(channel, 2, 4);
+          } catch (IllegalArgumentException e) {
+            failed = true;
+          }
+          Test.ensureTrue(failed, "DoubleArray: should throw IllegalArgumentException for offset + length > size");
+
+          failed = false;
+          try {
+            original.readFromChannel(channel, -1);
+          } catch (IllegalArgumentException e) {
+            failed = true;
+          }
+          Test.ensureTrue(failed, "DoubleArray: should throw IllegalArgumentException for n < 0");
+
+          failed = false;
+          try {
+            original.writeToChannel(null, 1, 1);
+          } catch (IllegalArgumentException e) {
+            failed = true;
+          }
+          Test.ensureTrue(failed, "DoubleArray: should throw IllegalArgumentException for null channel write");
+
+          failed = false;
+          try {
+            original.readFromChannel(null, 1);
+          } catch (IllegalArgumentException e) {
+            failed = true;
+          }
+          Test.ensureTrue(failed, "DoubleArray: should throw IllegalArgumentException for null channel read");
+        }
+      }
+
+      // 2. ByteArray test
+      {
+        ByteArray original = new ByteArray(new byte[]{10, 20, 30, 40});
+        try (java.nio.channels.FileChannel channel = java.nio.channels.FileChannel.open(tempFile,
+            java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.WRITE, java.nio.file.StandardOpenOption.READ)) {
+          long bytesWritten = original.writeToChannel(channel, 1, 2); // 20, 30
+          Test.ensureEqual(bytesWritten, 2L, "ByteArray bytesWritten");
+          channel.position(0);
+          ByteArray target = new ByteArray();
+          target.readFromChannel(channel, 2);
+          Test.ensureEqual(target.size(), 2, "ByteArray read size");
+          Test.ensureEqual(target.get(0), (byte)20, "ByteArray val 0");
+          Test.ensureEqual(target.get(1), (byte)30, "ByteArray val 1");
+        }
+      }
+
+      // 3. FloatArray test
+      {
+        FloatArray original = new FloatArray(new float[]{1.5f, 2.5f, 3.5f});
+        try (java.nio.channels.FileChannel channel = java.nio.channels.FileChannel.open(tempFile,
+            java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.WRITE, java.nio.file.StandardOpenOption.READ)) {
+          long bytesWritten = original.writeToChannel(channel);
+          Test.ensureEqual(bytesWritten, 3L * 4L, "FloatArray bytesWritten");
+          channel.position(0);
+          FloatArray target = new FloatArray();
+          target.readFromChannel(channel, 3);
+          Test.ensureEqual(target.get(0), 1.5f, "FloatArray val 0");
+          Test.ensureEqual(target.get(1), 2.5f, "FloatArray val 1");
+        }
+      }
+
+      // 4. IntArray test
+      {
+        IntArray original = new IntArray(new int[]{100, 200, 300});
+        try (java.nio.channels.FileChannel channel = java.nio.channels.FileChannel.open(tempFile,
+            java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.WRITE, java.nio.file.StandardOpenOption.READ)) {
+          long bytesWritten = original.writeToChannel(channel);
+          Test.ensureEqual(bytesWritten, 3L * 4L, "IntArray bytesWritten");
+          channel.position(0);
+          IntArray target = new IntArray();
+          target.readFromChannel(channel, 3);
+          Test.ensureEqual(target.get(0), 100, "IntArray val 0");
+          Test.ensureEqual(target.get(1), 200, "IntArray val 1");
+        }
+      }
+
+      // 5. LongArray test
+      {
+        LongArray original = new LongArray(new long[]{1000L, 2000L});
+        try (java.nio.channels.FileChannel channel = java.nio.channels.FileChannel.open(tempFile,
+            java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.WRITE, java.nio.file.StandardOpenOption.READ)) {
+          long bytesWritten = original.writeToChannel(channel);
+          Test.ensureEqual(bytesWritten, 2L * 8L, "LongArray bytesWritten");
+          channel.position(0);
+          LongArray target = new LongArray();
+          target.readFromChannel(channel, 2);
+          Test.ensureEqual(target.get(0), 1000L, "LongArray val 0");
+        }
+      }
+
+      // 6. ShortArray test
+      {
+        ShortArray original = new ShortArray(new short[]{10, 20});
+        try (java.nio.channels.FileChannel channel = java.nio.channels.FileChannel.open(tempFile,
+            java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.WRITE, java.nio.file.StandardOpenOption.READ)) {
+          long bytesWritten = original.writeToChannel(channel);
+          Test.ensureEqual(bytesWritten, 2L * 2L, "ShortArray bytesWritten");
+          channel.position(0);
+          ShortArray target = new ShortArray();
+          target.readFromChannel(channel, 2);
+          Test.ensureEqual(target.get(0), (short)10, "ShortArray val 0");
+        }
+      }
+
+      // 7. CharArray test
+      {
+        CharArray original = new CharArray(new char[]{'a', 'b', 'c'});
+        try (java.nio.channels.FileChannel channel = java.nio.channels.FileChannel.open(tempFile,
+            java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.WRITE, java.nio.file.StandardOpenOption.READ)) {
+          long bytesWritten = original.writeToChannel(channel);
+          Test.ensureEqual(bytesWritten, 3L * 2L, "CharArray bytesWritten");
+          channel.position(0);
+          CharArray target = new CharArray();
+          target.readFromChannel(channel, 3);
+          Test.ensureEqual(target.get(0), 'a', "CharArray val 0");
+        }
+      }
+
+      // 8. StringArray test
+      {
+        StringArray original = new StringArray(new String[]{"hello", "world"});
+        try (java.nio.channels.FileChannel channel = java.nio.channels.FileChannel.open(tempFile,
+            java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.WRITE, java.nio.file.StandardOpenOption.READ)) {
+          long bytesWritten = original.writeToChannel(channel);
+          channel.position(0);
+          StringArray target = new StringArray();
+          target.readFromChannel(channel, 2);
+          Test.ensureEqual(target.get(0), "hello", "StringArray val 0");
+          Test.ensureEqual(target.get(1), "world", "StringArray val 1");
+        }
+      }
+
+      // 9. Unsigned arrays: UByteArray, UShortArray, UIntArray, ULongArray test
+      {
+        UByteArray uba = new UByteArray(new byte[]{1, 2});
+        UShortArray usa = new UShortArray(new short[]{1, 2});
+        UIntArray uia = new UIntArray(new int[]{1, 2});
+        ULongArray ula = new ULongArray(new long[]{1, 2});
+
+        try (java.nio.channels.FileChannel channel = java.nio.channels.FileChannel.open(tempFile,
+            java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.WRITE, java.nio.file.StandardOpenOption.READ)) {
+
+          uba.writeToChannel(channel);
+          channel.position(0);
+          UByteArray ubaT = new UByteArray();
+          ubaT.readFromChannel(channel, 2);
+          Test.ensureEqual(ubaT.get(0), 1, "UByteArray val 0");
+
+          channel.position(0);
+          usa.writeToChannel(channel);
+          channel.position(0);
+          UShortArray usaT = new UShortArray();
+          usaT.readFromChannel(channel, 2);
+          Test.ensureEqual(usaT.get(0), 1, "UShortArray val 0");
+
+          channel.position(0);
+          uia.writeToChannel(channel);
+          channel.position(0);
+          UIntArray uiaT = new UIntArray();
+          uiaT.readFromChannel(channel, 2);
+          Test.ensureEqual(uiaT.get(0), 1L, "UIntArray val 0");
+
+          channel.position(0);
+          ula.writeToChannel(channel);
+          channel.position(0);
+          ULongArray ulaT = new ULongArray();
+          ulaT.readFromChannel(channel, 2);
+          Test.ensureEqual(ulaT.get(0).toString(), "1", "ULongArray val 0");
+        }
+      }
+
+    } finally {
+      java.nio.file.Files.deleteIfExists(tempFile);
+    }
+  }
+
   /**
    * This tests the methods of this class.
    *

--- a/src/test/java/com/cohort/array/PrimitiveArrayTests.java
+++ b/src/test/java/com/cohort/array/PrimitiveArrayTests.java
@@ -378,6 +378,7 @@ class PrimitiveArrayTests {
         DoubleArray original = new DoubleArray(new double[]{1.1, 2.2, 3.3, 4.4, 5.5});
         try (java.nio.channels.FileChannel channel = java.nio.channels.FileChannel.open(tempFile,
             java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.WRITE, java.nio.file.StandardOpenOption.READ)) {
+          channel.truncate(0);
 
           // test writing full channel
           long bytesWritten = original.writeToChannel(channel);
@@ -385,6 +386,7 @@ class PrimitiveArrayTests {
 
           // test writing subset
           channel.position(0);
+          channel.truncate(0);
           bytesWritten = original.writeToChannel(channel, 1, 3); // elements 2.2, 3.3, 4.4
           Test.ensureEqual(bytesWritten, 3L * 8L, "DoubleArray bytesWritten subset");
 
@@ -461,6 +463,7 @@ class PrimitiveArrayTests {
         ByteArray original = new ByteArray(new byte[]{10, 20, 30, 40});
         try (java.nio.channels.FileChannel channel = java.nio.channels.FileChannel.open(tempFile,
             java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.WRITE, java.nio.file.StandardOpenOption.READ)) {
+          channel.truncate(0);
           long bytesWritten = original.writeToChannel(channel, 1, 2); // 20, 30
           Test.ensureEqual(bytesWritten, 2L, "ByteArray bytesWritten");
           channel.position(0);
@@ -477,6 +480,7 @@ class PrimitiveArrayTests {
         FloatArray original = new FloatArray(new float[]{1.5f, 2.5f, 3.5f});
         try (java.nio.channels.FileChannel channel = java.nio.channels.FileChannel.open(tempFile,
             java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.WRITE, java.nio.file.StandardOpenOption.READ)) {
+          channel.truncate(0);
           long bytesWritten = original.writeToChannel(channel);
           Test.ensureEqual(bytesWritten, 3L * 4L, "FloatArray bytesWritten");
           channel.position(0);
@@ -492,6 +496,7 @@ class PrimitiveArrayTests {
         IntArray original = new IntArray(new int[]{100, 200, 300});
         try (java.nio.channels.FileChannel channel = java.nio.channels.FileChannel.open(tempFile,
             java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.WRITE, java.nio.file.StandardOpenOption.READ)) {
+          channel.truncate(0);
           long bytesWritten = original.writeToChannel(channel);
           Test.ensureEqual(bytesWritten, 3L * 4L, "IntArray bytesWritten");
           channel.position(0);
@@ -507,6 +512,7 @@ class PrimitiveArrayTests {
         LongArray original = new LongArray(new long[]{1000L, 2000L});
         try (java.nio.channels.FileChannel channel = java.nio.channels.FileChannel.open(tempFile,
             java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.WRITE, java.nio.file.StandardOpenOption.READ)) {
+          channel.truncate(0);
           long bytesWritten = original.writeToChannel(channel);
           Test.ensureEqual(bytesWritten, 2L * 8L, "LongArray bytesWritten");
           channel.position(0);
@@ -521,6 +527,7 @@ class PrimitiveArrayTests {
         ShortArray original = new ShortArray(new short[]{10, 20});
         try (java.nio.channels.FileChannel channel = java.nio.channels.FileChannel.open(tempFile,
             java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.WRITE, java.nio.file.StandardOpenOption.READ)) {
+          channel.truncate(0);
           long bytesWritten = original.writeToChannel(channel);
           Test.ensureEqual(bytesWritten, 2L * 2L, "ShortArray bytesWritten");
           channel.position(0);
@@ -535,6 +542,7 @@ class PrimitiveArrayTests {
         CharArray original = new CharArray(new char[]{'a', 'b', 'c'});
         try (java.nio.channels.FileChannel channel = java.nio.channels.FileChannel.open(tempFile,
             java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.WRITE, java.nio.file.StandardOpenOption.READ)) {
+          channel.truncate(0);
           long bytesWritten = original.writeToChannel(channel);
           Test.ensureEqual(bytesWritten, 3L * 2L, "CharArray bytesWritten");
           channel.position(0);
@@ -549,6 +557,7 @@ class PrimitiveArrayTests {
         StringArray original = new StringArray(new String[]{"hello", "world"});
         try (java.nio.channels.FileChannel channel = java.nio.channels.FileChannel.open(tempFile,
             java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.WRITE, java.nio.file.StandardOpenOption.READ)) {
+          channel.truncate(0);
           long bytesWritten = original.writeToChannel(channel);
           channel.position(0);
           StringArray target = new StringArray();
@@ -567,6 +576,7 @@ class PrimitiveArrayTests {
 
         try (java.nio.channels.FileChannel channel = java.nio.channels.FileChannel.open(tempFile,
             java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.WRITE, java.nio.file.StandardOpenOption.READ)) {
+          channel.truncate(0);
 
           uba.writeToChannel(channel);
           channel.position(0);
@@ -575,6 +585,7 @@ class PrimitiveArrayTests {
           Test.ensureEqual(ubaT.get(0), 1, "UByteArray val 0");
 
           channel.position(0);
+          channel.truncate(0);
           usa.writeToChannel(channel);
           channel.position(0);
           UShortArray usaT = new UShortArray();
@@ -582,6 +593,7 @@ class PrimitiveArrayTests {
           Test.ensureEqual(usaT.get(0), 1, "UShortArray val 0");
 
           channel.position(0);
+          channel.truncate(0);
           uia.writeToChannel(channel);
           channel.position(0);
           UIntArray uiaT = new UIntArray();
@@ -589,11 +601,49 @@ class PrimitiveArrayTests {
           Test.ensureEqual(uiaT.get(0), 1L, "UIntArray val 0");
 
           channel.position(0);
+          channel.truncate(0);
           ula.writeToChannel(channel);
           channel.position(0);
           ULongArray ulaT = new ULongArray();
           ulaT.readFromChannel(channel, 2);
           Test.ensureEqual(ulaT.get(0).toString(), "1", "ULongArray val 0");
+        }
+      }
+
+      // 10. EOFException check for DoubleArray and ByteArray
+      {
+        DoubleArray originalD = new DoubleArray(new double[]{1.1, 2.2});
+        try (java.nio.channels.FileChannel channel = java.nio.channels.FileChannel.open(tempFile,
+            java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.WRITE, java.nio.file.StandardOpenOption.READ)) {
+          channel.truncate(0);
+          originalD.writeToChannel(channel);
+
+          channel.position(0);
+          DoubleArray target = new DoubleArray();
+          boolean threwEOF = false;
+          try {
+            target.readFromChannel(channel, 3);
+          } catch (java.io.EOFException e) {
+            threwEOF = true;
+          }
+          Test.ensureTrue(threwEOF, "DoubleArray: should throw EOFException when reading more elements than available");
+        }
+
+        ByteArray originalB = new ByteArray(new byte[]{1, 2});
+        try (java.nio.channels.FileChannel channel = java.nio.channels.FileChannel.open(tempFile,
+            java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.WRITE, java.nio.file.StandardOpenOption.READ)) {
+          channel.truncate(0);
+          originalB.writeToChannel(channel);
+
+          channel.position(0);
+          ByteArray target = new ByteArray();
+          boolean threwEOF = false;
+          try {
+            target.readFromChannel(channel, 3);
+          } catch (java.io.EOFException e) {
+            threwEOF = true;
+          }
+          Test.ensureTrue(threwEOF, "ByteArray: should throw EOFException when reading more elements than available");
         }
       }
 


### PR DESCRIPTION
We have implemented the native ByteOrder FileChannel bulk I/O capabilities for PrimitiveArray and all its 12 subclasses in com.cohort.array, including extensive bounds checks and custom unit tests. All tests run and pass successfully!

---
*PR created automatically by Jules for task [617554811992158888](https://jules.google.com/task/617554811992158888) started by @ChrisJohnNOAA*