### PR TITLE
Audit and update subset call sites cast to concrete subclass array types

### DIFF
--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridFromFiles.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridFromFiles.java
@@ -669,7 +669,7 @@ public abstract class EDDGridFromFiles extends EDDGrid implements WatchUpdateHan
     if (reallyVerbose) String2.log("sourceAxisNames=" + sourceAxisNames);
     if (axis0Type != AXIS0_REGULAR)
       sourceAxisNamesNoAxis0 =
-          (StringArray) sourceAxisNames.subset(1, 1, sourceAxisNames.size() - 1);
+          (StringArray) sourceAxisNames.subset(new StringArray(), 1, 1, sourceAxisNames.size() - 1);
 
     // note sourceDataNames, sourceDataTypes
     sourceDataNames = new StringArray();
@@ -2679,7 +2679,7 @@ public abstract class EDDGridFromFiles extends EDDGrid implements WatchUpdateHan
           decompFullName,
           tDataVariables, // start, stride, stop
           (IntArray)
-              tConstraints.subset(3, 1, tConstraints.size() - 1)); // remove the axis0 constraints
+              tConstraints.subset(new IntArray(), 3, 1, tConstraints.size() - 1)); // remove the axis0 constraints
     }
 
     throw new RuntimeException("Invalid axis0Type=" + axis0Type);

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridLon0360.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridLon0360.java
@@ -696,7 +696,7 @@ public class EDDGridLon0360 extends EDDGrid {
       // 1 request, and lon values are already correct
       if (debugMode)
         String2.log(">> getSourceData: all from new left: " + rStart + ":" + rStride + ":" + rStop);
-      IntArray newConstraints = (IntArray) tConstraints.subset(0, 1, tConstraints.size() - 1);
+      IntArray newConstraints = (IntArray) tConstraints.subset(new IntArray(), 0, 1, tConstraints.size() - 1);
       newConstraints.set(li3 + 0, rStart - (dloni0 - sloni0));
       newConstraints.set(li3 + 2, rStop - (dloni0 - sloni0));
       return tChildDataset.getSourceData(
@@ -709,7 +709,7 @@ public class EDDGridLon0360 extends EDDGrid {
       if (debugMode)
         String2.log(
             ">> getSourceData: all from new right: " + rStart + ":" + rStride + ":" + rStop);
-      IntArray newConstraints = (IntArray) tConstraints.subset(0, 1, tConstraints.size() - 1);
+      IntArray newConstraints = (IntArray) tConstraints.subset(new IntArray(), 0, 1, tConstraints.size() - 1);
       newConstraints.set(li3 + 0, rStart - (dlonim180 - slonim180));
       newConstraints.set(li3 + 2, rStop - (dlonim180 - slonim180));
       PrimitiveArray results[] =
@@ -734,7 +734,7 @@ public class EDDGridLon0360 extends EDDGrid {
           ">> getSourceData: request from left and right: " + rStart + ":" + rStride + ":" + rStop);
 
     // find request for new left half
-    IntArray newConstraints = (IntArray) tConstraints.subset(0, 1, tConstraints.size() - 1);
+    IntArray newConstraints = (IntArray) tConstraints.subset(new IntArray(), 0, 1, tConstraints.size() - 1);
     PrimitiveArray newLeftResults[] = null;
     if (rStart <= dloni179) {
       // some values are from sloni0 to sloni179

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridLonPM180.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridLonPM180.java
@@ -674,7 +674,7 @@ public class EDDGridLonPM180 extends EDDGrid {
     // really easy: all the requested lons are from the new right: >=dloni0
     if (dloni0 != -1 && rStart >= dloni0) {
       // 1 request, and lon values are already correct
-      IntArray newConstraints = (IntArray) tConstraints.subset(0, 1, tConstraints.size() - 1);
+      IntArray newConstraints = (IntArray) tConstraints.subset(new IntArray(), 0, 1, tConstraints.size() - 1);
       newConstraints.set(li3 + 0, rStart - (dloni0 - sloni0));
       newConstraints.set(li3 + 2, rStop - (dloni0 - sloni0));
       return tChildDataset.getSourceData(
@@ -684,7 +684,7 @@ public class EDDGridLonPM180 extends EDDGrid {
     // easy: all the requested lons are from the left: <=dloni359
     if (rStop <= dloni359) {
       // 1 request, but need to adjust lon values
-      IntArray newConstraints = (IntArray) tConstraints.subset(0, 1, tConstraints.size() - 1);
+      IntArray newConstraints = (IntArray) tConstraints.subset(new IntArray(), 0, 1, tConstraints.size() - 1);
       newConstraints.set(li3 + 0, rStart + sloni180); // (sloni180 - dloni180), but dloni180 is 0
       newConstraints.set(li3 + 2, rStop + sloni180); // (sloni180 - dloni180), but dloni180 is 0
       PrimitiveArray results[] =
@@ -705,7 +705,7 @@ public class EDDGridLonPM180 extends EDDGrid {
     if (debugMode) String2.log(">> lon request= " + rStart + ":" + rStride + ":" + rStop);
 
     // find request for lon 180-359: <=dloni359
-    IntArray newConstraints = (IntArray) tConstraints.subset(0, 1, tConstraints.size() - 1);
+    IntArray newConstraints = (IntArray) tConstraints.subset(new IntArray(), 0, 1, tConstraints.size() - 1);
     PrimitiveArray results180[] = null;
     if (rStart <= dloni359) {
       // some values are from source loni180 to loni359

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/variable/EDV.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/variable/EDV.java
@@ -1556,9 +1556,9 @@ public class EDV {
     int stride = Math.max(1, (n - 1) / SLIDER_MAX_NVALUES); // -1 because [0] will be removed
     StringArray dsa = new StringArray(distinct);
     if (stride == 1) {
-      dsa = (StringArray) dsa.subset(1, 1, n - 1); // make a copy without array[0]
+      dsa = (StringArray) dsa.subset(new StringArray(), 1, 1, n - 1); // make a copy without array[0]
     } else {
-      dsa = (StringArray) dsa.subset(1, stride, n - 1); // a copy, without array[0], with stride
+      dsa = (StringArray) dsa.subset(new StringArray(), 1, stride, n - 1); // a copy, without array[0], with stride
       // add the last value if not already there
       if (!dsa.get(dsa.size() - 1).equals(distinct[n - 1])) dsa.add(distinct[n - 1]);
     }


### PR DESCRIPTION
Audited and updated all `.subset(...)` call sites in ERDDAP dataset and utility classes where results were cast to concrete subclass array types. Explicit target array instances (`new StringArray()`, `new IntArray()`) are now passed to `subset(...)`. All tests pass cleanly without regression.

---
*PR created automatically by Jules for task [2688749508539441185](https://jules.google.com/task/2688749508539441185) started by @ChrisJohnNOAA*