### PR TITLE
Implement OffsetScaleView for lazy linear scaling

### DIFF
--- a/WEB-INF/classes/com/cohort/array/Attributes.java
+++ b/WEB-INF/classes/com/cohort/array/Attributes.java
@@ -1192,7 +1192,7 @@ public class Attributes {
 
         // apply scaleAddOffset
         if (scale != 1 || add != 0) {
-          dataPa.scaleAddOffset(
+          dataPa = dataPa.scaleAddOffset(
               scale, add); // it checks for (1,0).  CoHort missing values are unaffected.
           if (debugMode) String2.log(">> #1: scale_factor=" + scale + " add_offset=" + add);
         }
@@ -1213,7 +1213,7 @@ public class Attributes {
                 && pa.elementType() != PAType.FLOAT
                 && pa.elementType() != PAType.DOUBLE) {
               pa = PrimitiveArray.factory(destPAType, pa);
-              pa.scaleAddOffset(scale, add);
+              pa = pa.scaleAddOffset(scale, add);
               newAtts.set(name, pa);
             }
           }
@@ -1260,7 +1260,7 @@ public class Attributes {
         PrimitiveArray pa = newAtts.remove(name);
         if (pa != null) {
           pa = new DoubleArray(pa);
-          pa.scaleAddOffset(baseFactor[1], baseFactor[0]);
+          pa = pa.scaleAddOffset(baseFactor[1], baseFactor[0]);
           newAtts.add(name, pa);
         }
       }
@@ -1509,7 +1509,7 @@ public class Attributes {
       }
 
       // apply scaleAddOffset
-      dataPa2.scaleAddOffset(scale, add); // it checks for (1,0)
+      dataPa2 = dataPa2.scaleAddOffset(scale, add); // it checks for (1,0)
       if (debugMode)
         String2.log(
             ">>   Attributes.unpackPA applied scale_factor="

--- a/WEB-INF/classes/com/cohort/array/ByteArray.java
+++ b/WEB-INF/classes/com/cohort/array/ByteArray.java
@@ -608,7 +608,7 @@ public class ByteArray extends PrimitiveArray {
   public PrimitiveArray addFromPA(final PrimitiveArray otherPA, int otherIndex, final int nValues) {
 
     // add from same type
-    if (otherPA.elementType() == elementType()) {
+    if (otherPA instanceof ByteArray otherByteArray) {
       if (otherIndex + nValues > otherPA.size)
         throw new IllegalArgumentException(
             String2.ERROR
@@ -619,7 +619,7 @@ public class ByteArray extends PrimitiveArray {
                 + " > otherPA.size="
                 + otherPA.size);
       ensureCapacity(size + nValues);
-      System.arraycopy(((ByteArray) otherPA).array, otherIndex, array, size, nValues);
+      System.arraycopy(otherByteArray.array, otherIndex, array, size, nValues);
       size += nValues;
       if (otherPA.getMaxIsMV()) maxIsMV = true;
       return this;

--- a/WEB-INF/classes/com/cohort/array/CharArray.java
+++ b/WEB-INF/classes/com/cohort/array/CharArray.java
@@ -507,7 +507,7 @@ public class CharArray extends PrimitiveArray {
   public PrimitiveArray addFromPA(final PrimitiveArray otherPA, int otherIndex, final int nValues) {
 
     // add from same type
-    if (otherPA.elementType() == elementType()) {
+    if (otherPA instanceof CharArray otherCharArray) {
       if (otherIndex + nValues > otherPA.size)
         throw new IllegalArgumentException(
             String2.ERROR

--- a/WEB-INF/classes/com/cohort/array/DoubleArray.java
+++ b/WEB-INF/classes/com/cohort/array/DoubleArray.java
@@ -460,7 +460,7 @@ public class DoubleArray extends PrimitiveArray {
   public PrimitiveArray addFromPA(final PrimitiveArray otherPA, int otherIndex, final int nValues) {
 
     // add from same type
-    if (otherPA.elementType() == elementType()) {
+    if (otherPA instanceof DoubleArray otherDoubleArray) {
       if (otherIndex + nValues > otherPA.size)
         throw new IllegalArgumentException(
             String2.ERROR
@@ -471,7 +471,7 @@ public class DoubleArray extends PrimitiveArray {
                 + " > otherPA.size="
                 + otherPA.size);
       ensureCapacity(size + nValues);
-      System.arraycopy(((DoubleArray) otherPA).array, otherIndex, array, size, nValues);
+      System.arraycopy(otherDoubleArray.array, otherIndex, array, size, nValues);
       size += nValues;
       return this;
     }

--- a/WEB-INF/classes/com/cohort/array/FloatArray.java
+++ b/WEB-INF/classes/com/cohort/array/FloatArray.java
@@ -446,7 +446,7 @@ public class FloatArray extends PrimitiveArray {
   public PrimitiveArray addFromPA(final PrimitiveArray otherPA, int otherIndex, final int nValues) {
 
     // add from same type
-    if (otherPA.elementType() == elementType()) {
+    if (otherPA instanceof FloatArray otherFloatArray) {
       if (otherIndex + nValues > otherPA.size)
         throw new IllegalArgumentException(
             String2.ERROR
@@ -457,7 +457,7 @@ public class FloatArray extends PrimitiveArray {
                 + " > otherPA.size="
                 + otherPA.size);
       ensureCapacity(size + nValues);
-      System.arraycopy(((FloatArray) otherPA).array, otherIndex, array, size, nValues);
+      System.arraycopy(otherFloatArray.array, otherIndex, array, size, nValues);
       size += nValues;
       return this;
     }

--- a/WEB-INF/classes/com/cohort/array/IntArray.java
+++ b/WEB-INF/classes/com/cohort/array/IntArray.java
@@ -493,7 +493,7 @@ public class IntArray extends PrimitiveArray {
   public PrimitiveArray addFromPA(final PrimitiveArray otherPA, int otherIndex, final int nValues) {
 
     // add from same type
-    if (otherPA.elementType() == elementType()) {
+    if (otherPA instanceof IntArray otherIntArray) {
       if (otherIndex + nValues > otherPA.size)
         throw new IllegalArgumentException(
             String2.ERROR
@@ -504,7 +504,7 @@ public class IntArray extends PrimitiveArray {
                 + " > otherPA.size="
                 + otherPA.size);
       ensureCapacity(size + nValues);
-      System.arraycopy(((IntArray) otherPA).array, otherIndex, array, size, nValues);
+      System.arraycopy(otherIntArray.array, otherIndex, array, size, nValues);
       size += nValues;
       if (otherPA.getMaxIsMV()) maxIsMV = true;
       return this;

--- a/WEB-INF/classes/com/cohort/array/LongArray.java
+++ b/WEB-INF/classes/com/cohort/array/LongArray.java
@@ -464,7 +464,7 @@ public class LongArray extends PrimitiveArray {
   public PrimitiveArray addFromPA(final PrimitiveArray otherPA, int otherIndex, final int nValues) {
 
     // add from same type
-    if (otherPA.elementType() == elementType()) {
+    if (otherPA instanceof LongArray otherLongArray) {
       if (otherIndex + nValues > otherPA.size)
         throw new IllegalArgumentException(
             String2.ERROR
@@ -475,7 +475,7 @@ public class LongArray extends PrimitiveArray {
                 + " > otherPA.size="
                 + otherPA.size);
       ensureCapacity(size + nValues);
-      System.arraycopy(((LongArray) otherPA).array, otherIndex, array, size, nValues);
+      System.arraycopy(otherLongArray.array, otherIndex, array, size, nValues);
       size += nValues;
       if (otherPA.getMaxIsMV()) maxIsMV = true;
       return this;

--- a/WEB-INF/classes/com/cohort/array/OffsetScaleView.java
+++ b/WEB-INF/classes/com/cohort/array/OffsetScaleView.java
@@ -118,6 +118,37 @@ public class OffsetScaleView extends PrimitiveView {
   }
 
   @Override
+  public double getNiceDouble(int index) {
+    checkIndexBounds(index);
+    PrimitiveArray m = materialized;
+    if (m != null) {
+      return m.getNiceDouble(index);
+    }
+    double d = getDouble(index);
+    return targetPAType == PAType.FLOAT ? Math2.floatToDouble((float) d) : d;
+  }
+
+  @Override
+  public double getRawDouble(int index) {
+    return getDouble(index);
+  }
+
+  @Override
+  public double getUnsignedDouble(int index) {
+    return getDouble(index);
+  }
+
+  @Override
+  public double getRawNiceDouble(int index) {
+    return getNiceDouble(index);
+  }
+
+  @Override
+  public int getRawInt(int index) {
+    return getInt(index);
+  }
+
+  @Override
   public float getFloat(int index) {
     checkIndexBounds(index);
     PrimitiveArray m = materialized;

--- a/WEB-INF/classes/com/cohort/array/OffsetScaleView.java
+++ b/WEB-INF/classes/com/cohort/array/OffsetScaleView.java
@@ -1,0 +1,293 @@
+package com.cohort.array;
+
+import com.cohort.util.Math2;
+import com.cohort.util.String2;
+
+/**
+ * OffsetScaleView provides a zero-copy virtual view over a PrimitiveArray (or PrimitiveView)
+ * applying a linear transformation (y = scale * x + offset) lazily.
+ */
+public class OffsetScaleView extends PrimitiveView {
+
+  public final double scale;
+  public final double offset;
+  public final double sourceMissingValue;
+  public final boolean sourceIsUnsigned;
+  private final PAType targetPAType;
+
+  public OffsetScaleView(PrimitiveArray source, double scale, double offset) {
+    this(source, false, source != null ? source.elementType() : PAType.DOUBLE, scale, offset);
+  }
+
+  public OffsetScaleView(PrimitiveArray source, PAType targetPAType, double scale, double offset) {
+    this(source, false, targetPAType, scale, offset);
+  }
+
+  public OffsetScaleView(
+      PrimitiveArray source,
+      boolean sourceIsUnsigned,
+      PAType targetPAType,
+      double scale,
+      double offset) {
+    this(
+        source,
+        sourceIsUnsigned,
+        targetPAType,
+        scale,
+        offset,
+        0,
+        1,
+        source != null ? source.size() : 0);
+  }
+
+  public OffsetScaleView(
+      PrimitiveArray source,
+      boolean sourceIsUnsigned,
+      PAType targetPAType,
+      double scale,
+      double offset,
+      int viewOffset,
+      int viewStride,
+      int viewLength) {
+    super(source, viewOffset, viewStride, viewLength);
+
+    double accumScale = scale;
+    double accumOffset = offset;
+    boolean accumUnsigned = sourceIsUnsigned;
+    PrimitiveArray current = source;
+
+    while (current instanceof PrimitiveView pv) {
+      if (pv.materialized != null) {
+        break;
+      }
+      if (pv instanceof OffsetScaleView osv) {
+        accumOffset = accumScale * osv.offset + accumOffset;
+        accumScale = accumScale * osv.scale;
+        accumUnsigned = accumUnsigned || osv.sourceIsUnsigned;
+      }
+      current = pv.source;
+    }
+
+    this.scale = accumScale;
+    this.offset = accumOffset;
+    this.sourceIsUnsigned = accumUnsigned;
+    this.targetPAType =
+        targetPAType != null
+            ? targetPAType
+            : (current != null ? current.elementType() : PAType.DOUBLE);
+    this.sourceMissingValue =
+        this.source != null ? this.source.missingValueAsDouble() : Double.NaN;
+  }
+
+  private void checkIndexBounds(int index) {
+    if (index < 0 || index >= size) {
+      throw new IndexOutOfBoundsException(
+          String2.ERROR
+              + " in OffsetScaleView: index ("
+              + index
+              + ") out of bounds for view size ("
+              + size
+              + ").");
+    }
+  }
+
+  @Override
+  public PAType elementType() {
+    PrimitiveArray m = materialized;
+    return m != null ? m.elementType() : targetPAType;
+  }
+
+  @Override
+  public double missingValueAsDouble() {
+    return targetPAType == PAType.FLOAT ? Float.NaN : Double.NaN;
+  }
+
+  @Override
+  public double getDouble(int index) {
+    checkIndexBounds(index);
+    PrimitiveArray m = materialized;
+    if (m != null) {
+      return m.getDouble(index);
+    }
+    double val =
+        sourceIsUnsigned
+            ? super.getUnsignedDouble(index)
+            : super.getDouble(index);
+    if (Double.isNaN(val)
+        || val == sourceMissingValue
+        || source.isMissingValue((int) (super.offset + (long) index * stride))) {
+      return Double.NaN;
+    }
+    return val * scale + offset;
+  }
+
+  @Override
+  public float getFloat(int index) {
+    checkIndexBounds(index);
+    PrimitiveArray m = materialized;
+    if (m != null) {
+      return m.getFloat(index);
+    }
+    double val = getDouble(index);
+    return Double.isNaN(val) ? Float.NaN : (float) val;
+  }
+
+  @Override
+  public int getInt(int index) {
+    checkIndexBounds(index);
+    PrimitiveArray m = materialized;
+    if (m != null) {
+      return m.getInt(index);
+    }
+    double d = getDouble(index);
+    if (Double.isNaN(d)) {
+      return Integer.MAX_VALUE;
+    }
+    return Math2.roundToInt(d);
+  }
+
+  @Override
+  public long getLong(int index) {
+    checkIndexBounds(index);
+    PrimitiveArray m = materialized;
+    if (m != null) {
+      return m.getLong(index);
+    }
+    double d = getDouble(index);
+    if (Double.isNaN(d)) {
+      return Long.MAX_VALUE;
+    }
+    return Math2.roundToLong(d);
+  }
+
+  @Override
+  public String getString(int index) {
+    checkIndexBounds(index);
+    PrimitiveArray m = materialized;
+    if (m != null) {
+      return m.getString(index);
+    }
+    if (targetPAType == PAType.FLOAT) {
+      float f = getFloat(index);
+      return Float.isNaN(f) ? "" : String.valueOf(f);
+    }
+    double d = getDouble(index);
+    return Double.isNaN(d) ? "" : String.valueOf(d);
+  }
+
+  @Override
+  public String getRawString(int index) {
+    return getString(index);
+  }
+
+  @Override
+  public String getRawestString(int index) {
+    return getString(index);
+  }
+
+  @Override
+  public PAOne getPAOne(int index) {
+    return getPAOne(index, new PAOne(elementType()));
+  }
+
+  @Override
+  public PAOne getPAOne(int index, PAOne paOne) {
+    checkIndexBounds(index);
+    PrimitiveArray m = materialized;
+    if (m != null) {
+      return m.getPAOne(index, paOne);
+    }
+    if (paOne == null) {
+      paOne = new PAOne(elementType());
+    }
+    if (targetPAType == PAType.FLOAT) {
+      return paOne.setFloat(getFloat(index));
+    }
+    return paOne.setDouble(getDouble(index));
+  }
+
+  @Override
+  public boolean isMissingValue(int index) {
+    checkIndexBounds(index);
+    PrimitiveArray m = materialized;
+    if (m != null) {
+      return m.isMissingValue(index);
+    }
+    double val =
+        sourceIsUnsigned
+            ? super.getUnsignedDouble(index)
+            : super.getDouble(index);
+    return Double.isNaN(val)
+        || val == sourceMissingValue
+        || source.isMissingValue((int) (super.offset + (long) index * stride));
+  }
+
+  @Override
+  public synchronized PrimitiveArray materialize() {
+    if (materialized == null) {
+      PrimitiveArray newArray = PrimitiveArray.factory(elementType(), size, false);
+      newArray.setMaxIsMV(getMaxIsMV());
+      for (int i = 0; i < size; i++) {
+        if (targetPAType == PAType.FLOAT) {
+          newArray.addFloat(getFloat(i));
+        } else {
+          newArray.addDouble(getDouble(i));
+        }
+      }
+      materialized = newArray;
+    }
+    return materialized;
+  }
+
+  @Override
+  public PrimitiveArray subset(PrimitiveArray pa, int startIndex, int stride, int stopIndex) {
+    if (startIndex < 0) {
+      throw new IllegalArgumentException(
+          String2.ERROR
+              + " in OffsetScaleView.subset: startIndex="
+              + startIndex
+              + " must be at least 0.");
+    }
+    if (stride < 1) {
+      throw new IllegalArgumentException(
+          String2.ERROR
+              + " in OffsetScaleView.subset: stride="
+              + stride
+              + " must be greater than 0.");
+    }
+    if (stopIndex < startIndex) {
+      if (pa == null)
+        return new OffsetScaleView(
+            source, sourceIsUnsigned, targetPAType, scale, offset, 0, 1, 0);
+      pa.clear();
+      return pa;
+    }
+    int effectiveStop = Math.min(stopIndex, size - 1);
+    int subLength = PrimitiveArray.strideWillFind(effectiveStop - startIndex + 1, stride);
+    if (pa == null) {
+      PrimitiveArray m = materialized;
+      if (m != null) {
+        return m.subset(null, startIndex, stride, effectiveStop);
+      }
+      return new OffsetScaleView(
+          source,
+          sourceIsUnsigned,
+          targetPAType,
+          scale,
+          offset,
+          (int) (super.offset + (long) startIndex * this.stride),
+          stride * this.stride,
+          subLength);
+    }
+
+    pa.clear();
+    PrimitiveArray m = materialized;
+    if (m != null) {
+      return m.subset(pa, startIndex, stride, effectiveStop);
+    }
+    for (int i = 0; i < subLength; i++) {
+      pa.addFromPA(this, startIndex + i * stride, 1);
+    }
+    return pa;
+  }
+}

--- a/WEB-INF/classes/com/cohort/array/OffsetScaleView.java
+++ b/WEB-INF/classes/com/cohort/array/OffsetScaleView.java
@@ -19,7 +19,8 @@ public class OffsetScaleView extends PrimitiveView {
     this(source, false, source != null ? source.elementType() : PAType.DOUBLE, scale, addOffset);
   }
 
-  public OffsetScaleView(PrimitiveArray source, PAType targetPAType, double scale, double addOffset) {
+  public OffsetScaleView(
+      PrimitiveArray source, PAType targetPAType, double scale, double addOffset) {
     this(source, false, targetPAType, scale, addOffset);
   }
 
@@ -71,8 +72,7 @@ public class OffsetScaleView extends PrimitiveView {
         targetPAType != null
             ? targetPAType
             : (this.source != null ? this.source.elementType() : PAType.DOUBLE);
-    this.sourceMissingValue =
-        this.source != null ? this.source.missingValueAsDouble() : Double.NaN;
+    this.sourceMissingValue = this.source != null ? this.source.missingValueAsDouble() : Double.NaN;
   }
 
   private void checkIndexBounds(int index) {
@@ -316,5 +316,82 @@ public class OffsetScaleView extends PrimitiveView {
       pa.addFromPA(this, startIndex + i * stride, 1);
     }
     return pa;
+  }
+
+  // Comparison: must use transformed (scaled/offset) values, so materialize when needed.
+  @Override
+  public int compare(int index1, PrimitiveArray otherPA, int index2) {
+    PrimitiveArray m = materialized;
+    if (m != null) return m.compare(index1, otherPA, index2);
+    return materialize().compare(index1, otherPA, index2);
+  }
+
+  @Override
+  public int compare(int index1, int index2) {
+    PrimitiveArray m = materialized;
+    if (m != null) return m.compare(index1, index2);
+    return materialize().compare(index1, index2);
+  }
+
+  // I/O: default PrimitiveView sometimes delegates directly to source which would bypass
+  // the scale/offset transformation. Ensure writes use the materialized (transformed)
+  // data to preserve semantics.
+  @Override
+  public long writeToChannel(java.nio.channels.FileChannel channel, int off, int len)
+      throws Exception {
+    PrimitiveArray m = materialized;
+    if (m != null) return m.writeToChannel(channel, off, len);
+    return materialize().writeToChannel(channel, off, len);
+  }
+
+  @Override
+  public long writeToChannel(java.nio.channels.FileChannel channel) throws Exception {
+    PrimitiveArray m = materialized;
+    if (m != null) return m.writeToChannel(channel);
+    return materialize().writeToChannel(channel);
+  }
+
+  @Override
+  public int writeDos(java.io.DataOutputStream dos) throws Exception {
+    PrimitiveArray m = materialized;
+    if (m != null) return m.writeDos(dos);
+    return materialize().writeDos(dos);
+  }
+
+  @Override
+  public int writeDos(java.io.DataOutputStream dos, int i) throws Exception {
+    PrimitiveArray m = materialized;
+    if (m != null) return m.writeDos(dos, i);
+    return materialize().writeDos(dos, i);
+  }
+
+  @Override
+  public void writeToRAF(java.io.RandomAccessFile raf, int index) throws Exception {
+    PrimitiveArray m = materialized;
+    if (m != null) {
+      m.writeToRAF(raf, index);
+      return;
+    }
+    materialize().writeToRAF(raf, index);
+  }
+
+  @Override
+  public void externalizeForDODS(java.io.DataOutputStream dos) throws Exception {
+    PrimitiveArray m = materialized;
+    if (m != null) {
+      m.externalizeForDODS(dos);
+      return;
+    }
+    materialize().externalizeForDODS(dos);
+  }
+
+  @Override
+  public void externalizeForDODS(java.io.DataOutputStream dos, int i) throws Exception {
+    PrimitiveArray m = materialized;
+    if (m != null) {
+      m.externalizeForDODS(dos, i);
+      return;
+    }
+    materialize().externalizeForDODS(dos, i);
   }
 }

--- a/WEB-INF/classes/com/cohort/array/OffsetScaleView.java
+++ b/WEB-INF/classes/com/cohort/array/OffsetScaleView.java
@@ -5,22 +5,22 @@ import com.cohort.util.String2;
 
 /**
  * OffsetScaleView provides a zero-copy virtual view over a PrimitiveArray (or PrimitiveView)
- * applying a linear transformation (y = scale * x + offset) lazily.
+ * applying a linear transformation (y = scale * x + addOffset) lazily.
  */
 public class OffsetScaleView extends PrimitiveView {
 
   public final double scale;
-  public final double offset;
+  public final double addOffset;
   public final double sourceMissingValue;
   public final boolean sourceIsUnsigned;
   private final PAType targetPAType;
 
-  public OffsetScaleView(PrimitiveArray source, double scale, double offset) {
-    this(source, false, source != null ? source.elementType() : PAType.DOUBLE, scale, offset);
+  public OffsetScaleView(PrimitiveArray source, double scale, double addOffset) {
+    this(source, false, source != null ? source.elementType() : PAType.DOUBLE, scale, addOffset);
   }
 
-  public OffsetScaleView(PrimitiveArray source, PAType targetPAType, double scale, double offset) {
-    this(source, false, targetPAType, scale, offset);
+  public OffsetScaleView(PrimitiveArray source, PAType targetPAType, double scale, double addOffset) {
+    this(source, false, targetPAType, scale, addOffset);
   }
 
   public OffsetScaleView(
@@ -28,13 +28,13 @@ public class OffsetScaleView extends PrimitiveView {
       boolean sourceIsUnsigned,
       PAType targetPAType,
       double scale,
-      double offset) {
+      double addOffset) {
     this(
         source,
         sourceIsUnsigned,
         targetPAType,
         scale,
-        offset,
+        addOffset,
         0,
         1,
         source != null ? source.size() : 0);
@@ -45,36 +45,32 @@ public class OffsetScaleView extends PrimitiveView {
       boolean sourceIsUnsigned,
       PAType targetPAType,
       double scale,
-      double offset,
+      double addOffset,
       int viewOffset,
       int viewStride,
       int viewLength) {
     super(source, viewOffset, viewStride, viewLength);
 
     double accumScale = scale;
-    double accumOffset = offset;
+    double accumOffset = addOffset;
     boolean accumUnsigned = sourceIsUnsigned;
     PrimitiveArray current = source;
 
-    while (current instanceof PrimitiveView pv) {
-      if (pv.materialized != null) {
-        break;
-      }
-      if (pv instanceof OffsetScaleView osv) {
-        accumOffset = accumScale * osv.offset + accumOffset;
-        accumScale = accumScale * osv.scale;
-        accumUnsigned = accumUnsigned || osv.sourceIsUnsigned;
-      }
-      current = pv.source;
+    while (current instanceof OffsetScaleView osv && osv.materialized == null) {
+      accumOffset = accumScale * osv.addOffset + accumOffset;
+      accumScale = accumScale * osv.scale;
+      accumUnsigned = accumUnsigned || osv.sourceIsUnsigned;
+      current = osv.source;
     }
 
     this.scale = accumScale;
-    this.offset = accumOffset;
+    this.addOffset = accumOffset;
     this.sourceIsUnsigned = accumUnsigned;
+
     this.targetPAType =
         targetPAType != null
             ? targetPAType
-            : (current != null ? current.elementType() : PAType.DOUBLE);
+            : (this.source != null ? this.source.elementType() : PAType.DOUBLE);
     this.sourceMissingValue =
         this.source != null ? this.source.missingValueAsDouble() : Double.NaN;
   }
@@ -111,14 +107,14 @@ public class OffsetScaleView extends PrimitiveView {
     }
     double val =
         sourceIsUnsigned
-            ? super.getUnsignedDouble(index)
-            : super.getDouble(index);
+            ? source.getUnsignedDouble(offset + index * stride)
+            : source.getDouble(offset + index * stride);
     if (Double.isNaN(val)
         || val == sourceMissingValue
-        || source.isMissingValue((int) (super.offset + (long) index * stride))) {
+        || source.isMissingValue(offset + index * stride)) {
       return Double.NaN;
     }
-    return val * scale + offset;
+    return val * scale + addOffset;
   }
 
   @Override
@@ -215,11 +211,11 @@ public class OffsetScaleView extends PrimitiveView {
     }
     double val =
         sourceIsUnsigned
-            ? super.getUnsignedDouble(index)
-            : super.getDouble(index);
+            ? source.getUnsignedDouble(offset + index * stride)
+            : source.getDouble(offset + index * stride);
     return Double.isNaN(val)
         || val == sourceMissingValue
-        || source.isMissingValue((int) (super.offset + (long) index * stride));
+        || source.isMissingValue(offset + index * stride);
   }
 
   @Override
@@ -258,7 +254,7 @@ public class OffsetScaleView extends PrimitiveView {
     if (stopIndex < startIndex) {
       if (pa == null)
         return new OffsetScaleView(
-            source, sourceIsUnsigned, targetPAType, scale, offset, 0, 1, 0);
+            source, sourceIsUnsigned, targetPAType, scale, addOffset, 0, 1, 0);
       pa.clear();
       return pa;
     }
@@ -274,8 +270,8 @@ public class OffsetScaleView extends PrimitiveView {
           sourceIsUnsigned,
           targetPAType,
           scale,
-          offset,
-          (int) (super.offset + (long) startIndex * this.stride),
+          addOffset,
+          (int) (this.offset + (long) startIndex * this.stride),
           stride * this.stride,
           subLength);
     }

--- a/WEB-INF/classes/com/cohort/array/PrimitiveArray.java
+++ b/WEB-INF/classes/com/cohort/array/PrimitiveArray.java
@@ -2840,13 +2840,22 @@ public abstract class PrimitiveArray {
    */
   public PrimitiveArray scaleAddOffset(
       boolean sourceIsUnsigned, PAType destElementPAType, double scale, double addOffset) {
-    if (scale == 1 && addOffset == 0 && !sourceIsUnsigned) {
-      if (elementType() == destElementPAType) {
-        return this;
-      }
-      return factory(destElementPAType, this);
+    if (this instanceof PrimitiveView pv && pv.materialized == null) {
+      return new OffsetScaleView(this, sourceIsUnsigned, destElementPAType, scale, addOffset);
     }
-    return new OffsetScaleView(this, sourceIsUnsigned, destElementPAType, scale, addOffset);
+    // Don't create a new PA if we don't need to.
+    PrimitiveArray pa = this;
+    if (this.elementType() != destElementPAType) {
+      pa = factory(destElementPAType, size, true);
+    }
+    if (sourceIsUnsigned) {
+      for (int i = 0; i < size; i++)
+        pa.setDouble(i, getUnsignedDouble(i) * scale + addOffset); // NaNs remain NaNs
+    } else {
+      for (int i = 0; i < size; i++)
+        pa.setDouble(i, getDouble(i) * scale + addOffset); // NaNs remain NaNs
+    }
+    return pa;
   }
 
   /**
@@ -2856,16 +2865,16 @@ public abstract class PrimitiveArray {
    * @param destElementPAType
    * @param addOffset
    * @param scale
-   * @return a new PrimitiveArray (an OffsetScaleView)
+   * @return a new PrimitiveArray
    */
   public PrimitiveArray addOffsetScale(PAType destElementPAType, double addOffset, double scale) {
-    if (scale == 1 && addOffset == 0) {
-      if (elementType() == destElementPAType) {
-        return this;
-      }
-      return factory(destElementPAType, this);
+    if (this instanceof PrimitiveView pv && pv.materialized == null) {
+      return new OffsetScaleView(this, false, destElementPAType, scale, addOffset * scale);
     }
-    return new OffsetScaleView(this, false, destElementPAType, scale, addOffset * scale);
+    PrimitiveArray pa = factory(destElementPAType, size, true);
+    for (int i = 0; i < size; i++)
+      pa.setDouble(i, (getDouble(i) + addOffset) * scale); // NaNs remain NaNs
+    return pa;
   }
 
   /**

--- a/WEB-INF/classes/com/cohort/array/PrimitiveArray.java
+++ b/WEB-INF/classes/com/cohort/array/PrimitiveArray.java
@@ -2840,21 +2840,13 @@ public abstract class PrimitiveArray {
    */
   public PrimitiveArray scaleAddOffset(
       boolean sourceIsUnsigned, PAType destElementPAType, double scale, double addOffset) {
-    if (scale == 1 && addOffset == 0 && elementType() == destElementPAType && !sourceIsUnsigned) {
-      return this;
+    if (scale == 1 && addOffset == 0 && !sourceIsUnsigned) {
+      if (elementType() == destElementPAType) {
+        return this;
+      }
+      return factory(destElementPAType, this);
     }
-    if ((this instanceof PrimitiveView pv && pv.materialized == null)
-        || this.elementType() != destElementPAType) {
-      return new OffsetScaleView(this, sourceIsUnsigned, destElementPAType, scale, addOffset);
-    }
-    if (sourceIsUnsigned) {
-      for (int i = 0; i < size; i++)
-        setDouble(i, getUnsignedDouble(i) * scale + addOffset); // NaNs remain NaNs
-    } else {
-      for (int i = 0; i < size; i++)
-        setDouble(i, getDouble(i) * scale + addOffset); // NaNs remain NaNs
-    }
-    return this;
+    return new OffsetScaleView(this, sourceIsUnsigned, destElementPAType, scale, addOffset);
   }
 
   /**
@@ -2864,19 +2856,16 @@ public abstract class PrimitiveArray {
    * @param destElementPAType
    * @param addOffset
    * @param scale
-   * @return a new PrimitiveArray
+   * @return a new PrimitiveArray (an OffsetScaleView)
    */
   public PrimitiveArray addOffsetScale(PAType destElementPAType, double addOffset, double scale) {
-    if (scale == 1 && addOffset == 0 && elementType() == destElementPAType) {
-      return this;
+    if (scale == 1 && addOffset == 0) {
+      if (elementType() == destElementPAType) {
+        return this;
+      }
+      return factory(destElementPAType, this);
     }
-    if ((this instanceof PrimitiveView pv && pv.materialized == null)
-        || this.elementType() != destElementPAType) {
-      return new OffsetScaleView(this, false, destElementPAType, scale, addOffset * scale);
-    }
-    for (int i = 0; i < size; i++)
-      setDouble(i, (getDouble(i) + addOffset) * scale); // NaNs remain NaNs
-    return this;
+    return new OffsetScaleView(this, false, destElementPAType, scale, addOffset * scale);
   }
 
   /**

--- a/WEB-INF/classes/com/cohort/array/PrimitiveArray.java
+++ b/WEB-INF/classes/com/cohort/array/PrimitiveArray.java
@@ -2846,7 +2846,7 @@ public abstract class PrimitiveArray {
     // Don't create a new PA if we don't need to.
     PrimitiveArray pa = this;
     if (this.elementType() != destElementPAType) {
-      pa = factory(destElementPAType, size, true);
+      return new OffsetScaleView(this, sourceIsUnsigned, destElementPAType, scale, addOffset);
     }
     if (sourceIsUnsigned) {
       for (int i = 0; i < size; i++)
@@ -2859,8 +2859,8 @@ public abstract class PrimitiveArray {
   }
 
   /**
-   * This returns a new PrimitiveArray of type destElementPAType which has had the packed
-   * values (addOffset then scale values applied).
+   * This returns a new PrimitiveArray of type destElementPAType which has had the packed values
+   * (addOffset then scale values applied).
    *
    * @param destElementPAType
    * @param addOffset
@@ -2868,13 +2868,7 @@ public abstract class PrimitiveArray {
    * @return a new PrimitiveArray
    */
   public PrimitiveArray addOffsetScale(PAType destElementPAType, double addOffset, double scale) {
-    if (this instanceof PrimitiveView pv && pv.materialized == null) {
-      return new OffsetScaleView(this, false, destElementPAType, scale, addOffset * scale);
-    }
-    PrimitiveArray pa = factory(destElementPAType, size, true);
-    for (int i = 0; i < size; i++)
-      pa.setDouble(i, (getDouble(i) + addOffset) * scale); // NaNs remain NaNs
-    return pa;
+    return new OffsetScaleView(this, false, destElementPAType, scale, addOffset * scale);
   }
 
   /**

--- a/WEB-INF/classes/com/cohort/array/PrimitiveArray.java
+++ b/WEB-INF/classes/com/cohort/array/PrimitiveArray.java
@@ -2795,7 +2795,12 @@ public abstract class PrimitiveArray {
    */
   public PrimitiveArray scaleAddOffset(double scale, double addOffset) {
     if (scale == 1 && addOffset == 0) return this;
-    return new OffsetScaleView(this, elementType(), scale, addOffset);
+    if (this instanceof PrimitiveView pv && pv.materialized == null) {
+      return new OffsetScaleView(this, elementType(), scale, addOffset);
+    }
+    for (int i = 0; i < size; i++)
+      setDouble(i, getDouble(i) * scale + addOffset); // NaNs remain NaNs
+    return this;
   }
 
   /**
@@ -2807,7 +2812,12 @@ public abstract class PrimitiveArray {
    */
   public PrimitiveArray addOffsetScale(double addOffset, double scale) {
     if (scale == 1 && addOffset == 0) return this;
-    return new OffsetScaleView(this, elementType(), scale, addOffset * scale);
+    if (this instanceof PrimitiveView pv && pv.materialized == null) {
+      return new OffsetScaleView(this, elementType(), scale, addOffset * scale);
+    }
+    for (int i = 0; i < size; i++)
+      setDouble(i, (getDouble(i) + addOffset) * scale); // NaNs remain NaNs
+    return this;
   }
 
   /** This variant assumes sourceIsUnsigned=false. */
@@ -2826,14 +2836,26 @@ public abstract class PrimitiveArray {
    *     values.
    * @param scale
    * @param addOffset
-   * @return a new PrimitiveArray (an OffsetScaleView)
+   * @return a new (always) PrimitiveArray
    */
   public PrimitiveArray scaleAddOffset(
       boolean sourceIsUnsigned, PAType destElementPAType, double scale, double addOffset) {
-    if (scale == 1 && addOffset == 0 && elementType() == destElementPAType && !sourceIsUnsigned) {
-      return this;
+    if (this instanceof PrimitiveView pv && pv.materialized == null) {
+      return new OffsetScaleView(this, sourceIsUnsigned, destElementPAType, scale, addOffset);
     }
-    return new OffsetScaleView(this, sourceIsUnsigned, destElementPAType, scale, addOffset);
+    // Don't create a new PA if we don't need to.
+    PrimitiveArray pa = this;
+    if (this.elementType() != destElementPAType) {
+      pa = factory(destElementPAType, size, true);
+    }
+    if (sourceIsUnsigned) {
+      for (int i = 0; i < size; i++)
+        pa.setDouble(i, getUnsignedDouble(i) * scale + addOffset); // NaNs remain NaNs
+    } else {
+      for (int i = 0; i < size; i++)
+        pa.setDouble(i, getDouble(i) * scale + addOffset); // NaNs remain NaNs
+    }
+    return pa;
   }
 
   /**
@@ -2843,13 +2865,16 @@ public abstract class PrimitiveArray {
    * @param destElementPAType
    * @param addOffset
    * @param scale
-   * @return a new PrimitiveArray (an OffsetScaleView)
+   * @return a new PrimitiveArray
    */
   public PrimitiveArray addOffsetScale(PAType destElementPAType, double addOffset, double scale) {
-    if (scale == 1 && addOffset == 0 && elementType() == destElementPAType) {
-      return this;
+    if (this instanceof PrimitiveView pv && pv.materialized == null) {
+      return new OffsetScaleView(this, false, destElementPAType, scale, addOffset * scale);
     }
-    return new OffsetScaleView(this, false, destElementPAType, scale, addOffset * scale);
+    PrimitiveArray pa = factory(destElementPAType, size, true);
+    for (int i = 0; i < size; i++)
+      pa.setDouble(i, (getDouble(i) + addOffset) * scale); // NaNs remain NaNs
+    return pa;
   }
 
   /**

--- a/WEB-INF/classes/com/cohort/array/PrimitiveArray.java
+++ b/WEB-INF/classes/com/cohort/array/PrimitiveArray.java
@@ -2795,12 +2795,7 @@ public abstract class PrimitiveArray {
    */
   public PrimitiveArray scaleAddOffset(double scale, double addOffset) {
     if (scale == 1 && addOffset == 0) return this;
-    if (this instanceof PrimitiveView pv && pv.materialized == null) {
-      return new OffsetScaleView(this, elementType(), scale, addOffset);
-    }
-    for (int i = 0; i < size; i++)
-      setDouble(i, getDouble(i) * scale + addOffset); // NaNs remain NaNs
-    return this;
+    return new OffsetScaleView(this, elementType(), scale, addOffset);
   }
 
   /**
@@ -2812,12 +2807,7 @@ public abstract class PrimitiveArray {
    */
   public PrimitiveArray addOffsetScale(double addOffset, double scale) {
     if (scale == 1 && addOffset == 0) return this;
-    if (this instanceof PrimitiveView pv && pv.materialized == null) {
-      return new OffsetScaleView(this, elementType(), scale, addOffset * scale);
-    }
-    for (int i = 0; i < size; i++)
-      setDouble(i, (getDouble(i) + addOffset) * scale); // NaNs remain NaNs
-    return this;
+    return new OffsetScaleView(this, elementType(), scale, addOffset * scale);
   }
 
   /** This variant assumes sourceIsUnsigned=false. */
@@ -2836,26 +2826,14 @@ public abstract class PrimitiveArray {
    *     values.
    * @param scale
    * @param addOffset
-   * @return a new (always) PrimitiveArray
+   * @return a new PrimitiveArray (an OffsetScaleView)
    */
   public PrimitiveArray scaleAddOffset(
       boolean sourceIsUnsigned, PAType destElementPAType, double scale, double addOffset) {
-    if (this instanceof PrimitiveView pv && pv.materialized == null) {
-      return new OffsetScaleView(this, sourceIsUnsigned, destElementPAType, scale, addOffset);
+    if (scale == 1 && addOffset == 0 && elementType() == destElementPAType && !sourceIsUnsigned) {
+      return this;
     }
-    // Don't create a new PA if we don't need to.
-    PrimitiveArray pa = this;
-    if (this.elementType() != destElementPAType) {
-      pa = factory(destElementPAType, size, true);
-    }
-    if (sourceIsUnsigned) {
-      for (int i = 0; i < size; i++)
-        pa.setDouble(i, getUnsignedDouble(i) * scale + addOffset); // NaNs remain NaNs
-    } else {
-      for (int i = 0; i < size; i++)
-        pa.setDouble(i, getDouble(i) * scale + addOffset); // NaNs remain NaNs
-    }
-    return pa;
+    return new OffsetScaleView(this, sourceIsUnsigned, destElementPAType, scale, addOffset);
   }
 
   /**
@@ -2865,16 +2843,13 @@ public abstract class PrimitiveArray {
    * @param destElementPAType
    * @param addOffset
    * @param scale
-   * @return a new PrimitiveArray
+   * @return a new PrimitiveArray (an OffsetScaleView)
    */
   public PrimitiveArray addOffsetScale(PAType destElementPAType, double addOffset, double scale) {
-    if (this instanceof PrimitiveView pv && pv.materialized == null) {
-      return new OffsetScaleView(this, false, destElementPAType, scale, addOffset * scale);
+    if (scale == 1 && addOffset == 0 && elementType() == destElementPAType) {
+      return this;
     }
-    PrimitiveArray pa = factory(destElementPAType, size, true);
-    for (int i = 0; i < size; i++)
-      pa.setDouble(i, (getDouble(i) + addOffset) * scale); // NaNs remain NaNs
-    return pa;
+    return new OffsetScaleView(this, false, destElementPAType, scale, addOffset * scale);
   }
 
   /**

--- a/WEB-INF/classes/com/cohort/array/PrimitiveArray.java
+++ b/WEB-INF/classes/com/cohort/array/PrimitiveArray.java
@@ -2793,10 +2793,14 @@ public abstract class PrimitiveArray {
    * @param scale
    * @param addOffset
    */
-  public void scaleAddOffset(double scale, double addOffset) {
-    if (scale == 1 && addOffset == 0) return;
+  public PrimitiveArray scaleAddOffset(double scale, double addOffset) {
+    if (scale == 1 && addOffset == 0) return this;
+    if (this instanceof PrimitiveView pv && pv.materialized == null) {
+      return new OffsetScaleView(this, elementType(), scale, addOffset);
+    }
     for (int i = 0; i < size; i++)
       setDouble(i, getDouble(i) * scale + addOffset); // NaNs remain NaNs
+    return this;
   }
 
   /**
@@ -2806,10 +2810,14 @@ public abstract class PrimitiveArray {
    * @param scale
    * @param addOffset
    */
-  public void addOffsetScale(double addOffset, double scale) {
-    if (scale == 1 && addOffset == 0) return;
+  public PrimitiveArray addOffsetScale(double addOffset, double scale) {
+    if (scale == 1 && addOffset == 0) return this;
+    if (this instanceof PrimitiveView pv && pv.materialized == null) {
+      return new OffsetScaleView(this, elementType(), scale, addOffset * scale);
+    }
     for (int i = 0; i < size; i++)
       setDouble(i, (getDouble(i) + addOffset) * scale); // NaNs remain NaNs
+    return this;
   }
 
   /** This variant assumes sourceIsUnsigned=false. */
@@ -2832,6 +2840,9 @@ public abstract class PrimitiveArray {
    */
   public PrimitiveArray scaleAddOffset(
       boolean sourceIsUnsigned, PAType destElementPAType, double scale, double addOffset) {
+    if (this instanceof PrimitiveView pv && pv.materialized == null) {
+      return new OffsetScaleView(this, sourceIsUnsigned, destElementPAType, scale, addOffset);
+    }
     // Don't create a new PA if we don't need to.
     PrimitiveArray pa = this;
     if (this.elementType() != destElementPAType) {
@@ -2858,6 +2869,9 @@ public abstract class PrimitiveArray {
    * @return a new (always) PrimitiveArray
    */
   public PrimitiveArray addOffsetScale(PAType destElementPAType, double addOffset, double scale) {
+    if (this instanceof PrimitiveView pv && pv.materialized == null) {
+      return new OffsetScaleView(this, false, destElementPAType, scale, addOffset * scale);
+    }
     PrimitiveArray pa = factory(destElementPAType, size, true);
     for (int i = 0; i < size; i++)
       pa.setDouble(i, (getDouble(i) + addOffset) * scale); // NaNs remain NaNs

--- a/WEB-INF/classes/com/cohort/array/PrimitiveArray.java
+++ b/WEB-INF/classes/com/cohort/array/PrimitiveArray.java
@@ -2840,42 +2840,26 @@ public abstract class PrimitiveArray {
    */
   public PrimitiveArray scaleAddOffset(
       boolean sourceIsUnsigned, PAType destElementPAType, double scale, double addOffset) {
-    if (this instanceof PrimitiveView pv && pv.materialized == null) {
-      return new OffsetScaleView(this, sourceIsUnsigned, destElementPAType, scale, addOffset);
+    if (scale == 1 && addOffset == 0 && elementType() == destElementPAType && !sourceIsUnsigned) {
+      return this;
     }
-    // Don't create a new PA if we don't need to.
-    PrimitiveArray pa = this;
-    if (this.elementType() != destElementPAType) {
-      pa = factory(destElementPAType, size, true);
-    }
-    if (sourceIsUnsigned) {
-      for (int i = 0; i < size; i++)
-        pa.setDouble(i, getUnsignedDouble(i) * scale + addOffset); // NaNs remain NaNs
-    } else {
-      for (int i = 0; i < size; i++)
-        pa.setDouble(i, getDouble(i) * scale + addOffset); // NaNs remain NaNs
-    }
-    return pa;
+    return new OffsetScaleView(this, sourceIsUnsigned, destElementPAType, scale, addOffset);
   }
 
   /**
-   * This returns a new (always) PrimitiveArray of type destElementPAType which has had the packed
-   * values (addOffset then scale values applied). Calculations are done as doubles then, if
-   * necessary, rounded and stored.
+   * This returns a new PrimitiveArray of type destElementPAType which has had the packed
+   * values (addOffset then scale values applied).
    *
    * @param destElementPAType
    * @param addOffset
    * @param scale
-   * @return a new (always) PrimitiveArray
+   * @return a new PrimitiveArray (an OffsetScaleView)
    */
   public PrimitiveArray addOffsetScale(PAType destElementPAType, double addOffset, double scale) {
-    if (this instanceof PrimitiveView pv && pv.materialized == null) {
-      return new OffsetScaleView(this, false, destElementPAType, scale, addOffset * scale);
+    if (scale == 1 && addOffset == 0 && elementType() == destElementPAType) {
+      return this;
     }
-    PrimitiveArray pa = factory(destElementPAType, size, true);
-    for (int i = 0; i < size; i++)
-      pa.setDouble(i, (getDouble(i) + addOffset) * scale); // NaNs remain NaNs
-    return pa;
+    return new OffsetScaleView(this, false, destElementPAType, scale, addOffset * scale);
   }
 
   /**

--- a/WEB-INF/classes/com/cohort/array/PrimitiveArray.java
+++ b/WEB-INF/classes/com/cohort/array/PrimitiveArray.java
@@ -2843,7 +2843,18 @@ public abstract class PrimitiveArray {
     if (scale == 1 && addOffset == 0 && elementType() == destElementPAType && !sourceIsUnsigned) {
       return this;
     }
-    return new OffsetScaleView(this, sourceIsUnsigned, destElementPAType, scale, addOffset);
+    if ((this instanceof PrimitiveView pv && pv.materialized == null)
+        || this.elementType() != destElementPAType) {
+      return new OffsetScaleView(this, sourceIsUnsigned, destElementPAType, scale, addOffset);
+    }
+    if (sourceIsUnsigned) {
+      for (int i = 0; i < size; i++)
+        setDouble(i, getUnsignedDouble(i) * scale + addOffset); // NaNs remain NaNs
+    } else {
+      for (int i = 0; i < size; i++)
+        setDouble(i, getDouble(i) * scale + addOffset); // NaNs remain NaNs
+    }
+    return this;
   }
 
   /**
@@ -2853,13 +2864,19 @@ public abstract class PrimitiveArray {
    * @param destElementPAType
    * @param addOffset
    * @param scale
-   * @return a new PrimitiveArray (an OffsetScaleView)
+   * @return a new PrimitiveArray
    */
   public PrimitiveArray addOffsetScale(PAType destElementPAType, double addOffset, double scale) {
     if (scale == 1 && addOffset == 0 && elementType() == destElementPAType) {
       return this;
     }
-    return new OffsetScaleView(this, false, destElementPAType, scale, addOffset * scale);
+    if ((this instanceof PrimitiveView pv && pv.materialized == null)
+        || this.elementType() != destElementPAType) {
+      return new OffsetScaleView(this, false, destElementPAType, scale, addOffset * scale);
+    }
+    for (int i = 0; i < size; i++)
+      setDouble(i, (getDouble(i) + addOffset) * scale); // NaNs remain NaNs
+    return this;
   }
 
   /**

--- a/WEB-INF/classes/com/cohort/array/PrimitiveView.java
+++ b/WEB-INF/classes/com/cohort/array/PrimitiveView.java
@@ -766,6 +766,7 @@ public class PrimitiveView extends PrimitiveArray {
    *
    * @return A 1D primitive or object array matching this view's element type.
    */
+  @Override
   public Object toObjectArray() {
     // 1. Delegate to PrimitiveArray if already materialized
     PrimitiveArray m = materialized;

--- a/WEB-INF/classes/com/cohort/array/ShortArray.java
+++ b/WEB-INF/classes/com/cohort/array/ShortArray.java
@@ -520,7 +520,7 @@ public class ShortArray extends PrimitiveArray {
   public PrimitiveArray addFromPA(final PrimitiveArray otherPA, int otherIndex, final int nValues) {
 
     // add from same type
-    if (otherPA.elementType() == elementType()) {
+    if (otherPA instanceof ShortArray otherShortArray) {
       if (otherIndex + nValues > otherPA.size)
         throw new IllegalArgumentException(
             String2.ERROR
@@ -531,7 +531,7 @@ public class ShortArray extends PrimitiveArray {
                 + " > otherPA.size="
                 + otherPA.size);
       ensureCapacity(size + nValues);
-      System.arraycopy(((ShortArray) otherPA).array, otherIndex, array, size, nValues);
+      System.arraycopy(otherShortArray.array, otherIndex, array, size, nValues);
       size += nValues;
       if (otherPA.getMaxIsMV()) maxIsMV = true;
       return this;

--- a/WEB-INF/classes/com/cohort/array/StringArray.java
+++ b/WEB-INF/classes/com/cohort/array/StringArray.java
@@ -800,7 +800,7 @@ public class StringArray extends PrimitiveArray {
   public PrimitiveArray addFromPA(final PrimitiveArray otherPA, int otherIndex, final int nValues) {
 
     // add from same type
-    if (otherPA.elementType() == elementType()) {
+    if (otherPA instanceof StringArray otherStringArray) {
       if (otherIndex + nValues > otherPA.size)
         throw new IllegalArgumentException(
             String2.ERROR
@@ -811,7 +811,7 @@ public class StringArray extends PrimitiveArray {
                 + " > otherPA.size="
                 + otherPA.size);
       ensureCapacity(size + nValues);
-      System.arraycopy(((StringArray) otherPA).array, otherIndex, array, size, nValues);
+      System.arraycopy(otherStringArray.array, otherIndex, array, size, nValues);
       size += nValues;
       return this;
     }

--- a/WEB-INF/classes/com/cohort/array/UByteArray.java
+++ b/WEB-INF/classes/com/cohort/array/UByteArray.java
@@ -669,7 +669,7 @@ public class UByteArray extends PrimitiveArray {
   public PrimitiveArray addFromPA(final PrimitiveArray otherPA, int otherIndex, final int nValues) {
 
     // add from same type
-    if (otherPA.elementType() == elementType()) {
+    if (otherPA instanceof UByteArray otherUByteArray) {
       if (otherIndex + nValues > otherPA.size)
         throw new IllegalArgumentException(
             String2.ERROR
@@ -680,7 +680,7 @@ public class UByteArray extends PrimitiveArray {
                 + " > otherPA.size="
                 + otherPA.size);
       ensureCapacity(size + nValues);
-      System.arraycopy(((UByteArray) otherPA).array, otherIndex, array, size, nValues);
+      System.arraycopy(otherUByteArray.array, otherIndex, array, size, nValues);
       size += nValues;
       if (otherPA.getMaxIsMV()) maxIsMV = true;
       return this;

--- a/WEB-INF/classes/com/cohort/array/UIntArray.java
+++ b/WEB-INF/classes/com/cohort/array/UIntArray.java
@@ -559,7 +559,7 @@ public class UIntArray extends PrimitiveArray {
   public PrimitiveArray addFromPA(final PrimitiveArray otherPA, int otherIndex, final int nValues) {
 
     // add from same type
-    if (otherPA.elementType() == elementType()) {
+    if (otherPA instanceof UIntArray otherUIntArray) {
       if (otherIndex + nValues > otherPA.size)
         throw new IllegalArgumentException(
             String2.ERROR
@@ -570,7 +570,7 @@ public class UIntArray extends PrimitiveArray {
                 + " > otherPA.size="
                 + otherPA.size);
       ensureCapacity(size + nValues);
-      System.arraycopy(((UIntArray) otherPA).array, otherIndex, array, size, nValues);
+      System.arraycopy(otherUIntArray.array, otherIndex, array, size, nValues);
       size += nValues;
       if (otherPA.getMaxIsMV()) maxIsMV = true;
       return this;

--- a/WEB-INF/classes/com/cohort/array/ULongArray.java
+++ b/WEB-INF/classes/com/cohort/array/ULongArray.java
@@ -590,7 +590,7 @@ public class ULongArray extends PrimitiveArray {
   public PrimitiveArray addFromPA(final PrimitiveArray otherPA, int otherIndex, final int nValues) {
 
     // add from same type
-    if (otherPA.elementType() == elementType()) {
+    if (otherPA instanceof ULongArray otherULongArray) {
       if (otherIndex + nValues > otherPA.size)
         throw new IllegalArgumentException(
             String2.ERROR
@@ -601,7 +601,7 @@ public class ULongArray extends PrimitiveArray {
                 + " > otherPA.size="
                 + otherPA.size);
       ensureCapacity(size + nValues);
-      System.arraycopy(((ULongArray) otherPA).array, otherIndex, array, size, nValues);
+      System.arraycopy(otherULongArray.array, otherIndex, array, size, nValues);
       size += nValues;
       if (otherPA.getMaxIsMV()) maxIsMV = true;
       return this;

--- a/WEB-INF/classes/com/cohort/array/UShortArray.java
+++ b/WEB-INF/classes/com/cohort/array/UShortArray.java
@@ -593,7 +593,7 @@ public class UShortArray extends PrimitiveArray {
   public PrimitiveArray addFromPA(final PrimitiveArray otherPA, int otherIndex, final int nValues) {
 
     // add from same type
-    if (otherPA.elementType() == elementType()) {
+    if (otherPA instanceof UShortArray otherUShortArray) {
       if (otherIndex + nValues > otherPA.size)
         throw new IllegalArgumentException(
             String2.ERROR
@@ -604,7 +604,7 @@ public class UShortArray extends PrimitiveArray {
                 + " > otherPA.size="
                 + otherPA.size);
       ensureCapacity(size + nValues);
-      System.arraycopy(((UShortArray) otherPA).array, otherIndex, array, size, nValues);
+      System.arraycopy(otherUShortArray.array, otherIndex, array, size, nValues);
       size += nValues;
       if (otherPA.getMaxIsMV()) maxIsMV = true;
       return this;

--- a/WEB-INF/classes/gov/noaa/pfel/coastwatch/griddata/Opendap.java
+++ b/WEB-INF/classes/gov/noaa/pfel/coastwatch/griddata/Opendap.java
@@ -798,8 +798,8 @@ public class Opendap {
           grid.lat, rightGrid.lat, errorInMethod + "Unexpected: The lat arrays don't match.");
       DoubleArray lonDA = new DoubleArray(grid.lon);
       DoubleArray rightLonDA = new DoubleArray(rightGrid.lon);
-      if (lonIsPM180) rightLonDA.scaleAddOffset(1, 360);
-      else lonDA.scaleAddOffset(1, -360);
+      if (lonIsPM180) rightLonDA = (DoubleArray) rightLonDA.scaleAddOffset(1, 360);
+      else lonDA = (DoubleArray) lonDA.scaleAddOffset(1, -360);
 
       DoubleArray dataDA = new DoubleArray(grid.data);
       DoubleArray rightDataDA = new DoubleArray(rightGrid.data);

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/Erddap.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/Erddap.java
@@ -11147,7 +11147,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         if (avi == eddGrid.depthIndex()) {
           // convert depth to elevation
           PrimitiveArray elevValues = (PrimitiveArray) av.destinationValues().clone();
-          elevValues.scaleAddOffset(-1, 0);
+          elevValues = elevValues.scaleAddOffset(-1, 0);
           if (elevValues.size() > 2 && av.isEvenlySpaced()) {
             // min/max/spacing
             writer.write(
@@ -11482,7 +11482,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         tpa = gaa[gai].destinationStringValues(); // ISO 8601
       } else {
         tpa = (PrimitiveArray) gaa[gai].destinationValues().clone();
-        if (gai == depthi) tpa.scaleAddOffset(-1, 0); // convert depth to elevation
+        if (gai == depthi) tpa = tpa.scaleAddOffset(-1, 0); // convert depth to elevation
         tpa.sort(); // people want + button to increase values and - button to decrease
       }
       options[gai] = tpa.toStringArray();

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDD.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDD.java
@@ -9016,7 +9016,7 @@ public abstract class EDD {
           // their PATypes are numeric but different
           arPa = PrimitiveArray.factory(saPaPAType, arPa);
           if (arPa.isIntegerType() && saPa.isFloatingPointType()) // covers most cases
-          arPa.scaleAddOffset(tScaleFactor, tAddOffset);
+          arPa = arPa.scaleAddOffset(tScaleFactor, tAddOffset);
           addAtts.set("actual_range", arPa);
         }
       }
@@ -10316,7 +10316,7 @@ public abstract class EDD {
           isDegreesC = true;
           tUnits = "degree_C";
           ao = (PrimitiveArray) ao.clone(); // if from sourceAtts, don't change sourceAtts value
-          ao.scaleAddOffset(1.0, Math2.kelvinToC);
+          ao = ao.scaleAddOffset(1.0, Math2.kelvinToC);
           tAddOffset = ao.getDouble(0);
           addAtts.set("add_offset", ao);
         }

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGrid.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGrid.java
@@ -6139,7 +6139,7 @@ public abstract class EDDGrid extends EDD {
           stdShape[a] = pa.size();
           Dimension tDim = NcHelper.addDimension(rootGroup, avName, pa.size());
           axisDimensionList.add(tDim);
-          if (av == lonIndex) pa.scaleAddOffset(1, lonAdjust);
+          if (av == lonIndex) pa = pa.scaleAddOffset(1, lonAdjust);
           axisArrays[a] =
               Array.factory(
                   NcHelper.getNc3DataType(gda.axisValues(av).elementType()),

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridLon0360.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridLon0360.java
@@ -444,8 +444,7 @@ public class EDDGridLon0360 extends EDDGrid {
     // finish making newLonValues: append the m180 ... m1 lon values
     dlonim180 = newLonValues.size();
     PrimitiveArray tLonValues =
-        childLonValues.subset(slonim180, 1, slonim1); // always a new backing array
-    tLonValues.addOffsetScale(360, 1); // -180 ... -1 -> 180 ... 359
+        childLonValues.subset(slonim180, 1, slonim1).addOffsetScale(360, 1); // -180 ... -1 -> 180 ... 359
     newLonValues.append(tLonValues);
     int dlonim1 = newLonValues.size() - 1;
 
@@ -717,8 +716,7 @@ public class EDDGridLon0360 extends EDDGrid {
       PrimitiveArray results[] =
           tChildDataset.getSourceData(
               language, tDirTable, tFileTable, tDataVariables, newConstraints);
-      results[lonIndex] = (PrimitiveArray) results[lonIndex].clone();
-      results[lonIndex].addOffsetScale(360, 1);
+      results[lonIndex] = ((PrimitiveArray) results[lonIndex].clone()).addOffsetScale(360, 1);
       return results;
     }
 
@@ -746,8 +744,7 @@ public class EDDGridLon0360 extends EDDGrid {
       newLeftResults =
           tChildDataset.getSourceData(
               language, tDirTable, tFileTable, tDataVariables, newConstraints);
-      newLeftResults[lonIndex] = (PrimitiveArray) newLeftResults[lonIndex].clone();
-      newLeftResults[lonIndex].addOffsetScale(-360, 1);
+      newLeftResults[lonIndex] = ((PrimitiveArray) newLeftResults[lonIndex].clone()).addOffsetScale(-360, 1);
       if (debugMode)
         String2.log(
             ">> got newLeftResults from source lon["

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridLonPM180.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridLonPM180.java
@@ -393,8 +393,7 @@ public class EDDGridLonPM180 extends EDDGrid {
         childLonValues.getDouble(sloni0) == 0) // with value == 0
     sloni359--; // maxSourceLon is a duplicate of 0, so ignore it
     PrimitiveArray newLonValues =
-        childLonValues.subset(sloni180, 1, sloni359); // always a new backing array
-    newLonValues.addOffsetScale(-360, 1); // 180 ... 359 -> -180 ... -1
+        childLonValues.subset(sloni180, 1, sloni359).addOffsetScale(-360, 1); // 180 ... 359 -> -180 ... -1
 
     // set dloni: where are sloni after source values are rearranged to dest values
     int dloni180 = 0;
@@ -692,8 +691,7 @@ public class EDDGridLonPM180 extends EDDGrid {
       PrimitiveArray results[] =
           tChildDataset.getSourceData(
               language, tDirTable, tFileTable, tDataVariables, newConstraints);
-      results[lonIndex] = (PrimitiveArray) results[lonIndex].clone();
-      results[lonIndex].addOffsetScale(-360, 1);
+      results[lonIndex] = ((PrimitiveArray) results[lonIndex].clone()).addOffsetScale(-360, 1);
       return results;
     }
 
@@ -717,8 +715,7 @@ public class EDDGridLonPM180 extends EDDGrid {
       results180 =
           tChildDataset.getSourceData(
               language, tDirTable, tFileTable, tDataVariables, newConstraints);
-      results180[lonIndex] = (PrimitiveArray) results180[lonIndex].clone();
-      results180[lonIndex].addOffsetScale(-360, 1);
+      results180[lonIndex] = ((PrimitiveArray) results180[lonIndex].clone()).addOffsetScale(-360, 1);
       if (debugMode)
         String2.log(
             ">> got results180 from source lon["

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromFileNames.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromFileNames.java
@@ -880,7 +880,7 @@ public class EDDTableFromFileNames extends EDDTable {
         // The proper query above converts lastMod to double epochSeconds
         // so convert back to long epochMillis.
         dnlsTable = twardt.cumulativeTable();
-        dnlsTable.getColumn(2).scaleAddOffset(1000, 0);
+        dnlsTable.setColumn(2, dnlsTable.getColumn(2).scaleAddOffset(1000, 0));
         dnlsTable.setColumn(2, new LongArray(dnlsTable.getColumn(2)));
         dnlsTable.columnAttributes(2).set("units", "milliseconds since 1970-01-01T00:00:00Z");
         dnlsTable.sortIgnoreCase(new int[] {1}, new boolean[] {true});
@@ -1377,7 +1377,7 @@ public class EDDTableFromFileNames extends EDDTable {
         // convert last mod from millis to seconds
         int lastModc = table.findColumnNumber("lastModified");
         PrimitiveArray lastModPA = table.getColumn(lastModc);
-        lastModPA.scaleAddOffset(0.001, 0);
+        lastModPA = lastModPA.scaleAddOffset(0.001, 0);
         table.columnAttributes(lastModc).set("units", Calendar2.SECONDS_SINCE_1970);
 
         // if (sti == 0) String2.log("\nbefore convert to urls:\n" + table.dataToString(5));

--- a/src/test/java/com/cohort/array/PrimitiveViewTests.java
+++ b/src/test/java/com/cohort/array/PrimitiveViewTests.java
@@ -149,4 +149,109 @@ class PrimitiveViewTests {
     Test.ensureEqual(view.toCSVString(), "2,3", "toCSVString format");
     Test.ensureEqual(view.toJsonCsvString(), "2, 3", "toJsonCsvString format");
   }
+
+  @org.junit.jupiter.api.Test
+  void testOffsetScaleViewBasicAndMath() {
+    DoubleArray da = new DoubleArray(new double[] {10.0, 20.0, 30.0, 40.0});
+    PrimitiveView baseView = new PrimitiveView(da, 0, 1, 4);
+
+    // scale = 2.0, offset = -5.0 -> y = 2.0 * x - 5.0
+    PrimitiveArray scaled = baseView.scaleAddOffset(2.0, -5.0);
+    Test.ensureTrue(scaled instanceof OffsetScaleView, "scaleAddOffset returns OffsetScaleView");
+    OffsetScaleView osv = (OffsetScaleView) scaled;
+
+    Test.ensureEqual(osv.size(), 4, "size");
+    Test.ensureEqual(osv.getDouble(0), 15.0, "getDouble(0) = 2*10 - 5");
+    Test.ensureEqual(osv.getDouble(1), 35.0, "getDouble(1) = 2*20 - 5");
+    Test.ensureEqual(osv.getDouble(2), 55.0, "getDouble(2) = 2*30 - 5");
+    Test.ensureEqual(osv.getDouble(3), 75.0, "getDouble(3) = 2*40 - 5");
+
+    // Negative scale & positive offset
+    PrimitiveArray scaledNeg = baseView.scaleAddOffset(-0.5, 100.0);
+    Test.ensureEqual(scaledNeg.getDouble(0), 95.0, "getDouble(0) = -0.5*10 + 100");
+    Test.ensureEqual(scaledNeg.getDouble(1), 90.0, "getDouble(1) = -0.5*20 + 100");
+
+    // addOffsetScale: y = (x + 360) * 1
+    PrimitiveArray packed = baseView.addOffsetScale(360.0, 1.0);
+    Test.ensureTrue(packed instanceof OffsetScaleView, "addOffsetScale returns OffsetScaleView");
+    Test.ensureEqual(packed.getDouble(0), 370.0, "addOffsetScale getDouble(0) = 10 + 360");
+  }
+
+  @org.junit.jupiter.api.Test
+  void testOffsetScaleViewMissingValuesAndNaN() {
+    ByteArray ba = new ByteArray(new byte[] {10, (byte) 127, 30}); // 127 is ByteArray missing value
+    PrimitiveView baseView = new PrimitiveView(ba, 0, 1, 3);
+    PrimitiveArray scaled = baseView.scaleAddOffset(0.1, 5.0);
+
+    Test.ensureEqual(scaled.getDouble(0), 6.0, "scaled[0] = 10*0.1 + 5");
+    Test.ensureTrue(Double.isNaN(scaled.getDouble(1)), "scaled[1] sentinel 127 returns NaN");
+    Test.ensureTrue(scaled.isMissingValue(1), "isMissingValue(1) returns true");
+    Test.ensureEqual(scaled.getDouble(2), 8.0, "scaled[2] = 30*0.1 + 5");
+
+    DoubleArray daNaN = new DoubleArray(new double[] {1.0, Double.NaN, 3.0});
+    PrimitiveView viewNaN = new PrimitiveView(daNaN, 0, 1, 3);
+    PrimitiveArray scaledNaN = viewNaN.scaleAddOffset(10.0, 1.0);
+
+    Test.ensureEqual(scaledNaN.getDouble(0), 11.0, "scaledNaN[0]");
+    Test.ensureTrue(Double.isNaN(scaledNaN.getDouble(1)), "scaledNaN[1] Double.NaN preserved");
+    Test.ensureTrue(scaledNaN.isMissingValue(1), "isMissingValue(1) returns true for NaN");
+    Test.ensureEqual(scaledNaN.getDouble(2), 31.0, "scaledNaN[2]");
+  }
+
+  @org.junit.jupiter.api.Test
+  void testOffsetScaleViewUnmaterializedRead() {
+    IntArray ia = new IntArray(new int[] {100, 200, 300, 400});
+    PrimitiveView baseView = new PrimitiveView(ia, 0, 1, 4);
+    PrimitiveArray scaled = baseView.scaleAddOffset(1.5, 10.0);
+
+    Test.ensureTrue(baseView.materialized == null, "baseView materialized null before reads");
+    Test.ensureTrue(scaled instanceof OffsetScaleView, "is OffsetScaleView");
+    OffsetScaleView osv = (OffsetScaleView) scaled;
+    Test.ensureTrue(osv.materialized == null, "osv materialized null before reads");
+
+    // Read all elements through view
+    for (int i = 0; i < osv.size(); i++) {
+      double v = osv.getDouble(i);
+      Test.ensureEqual(v, (100 * (i + 1)) * 1.5 + 10.0, "osv getDouble(" + i + ")");
+    }
+
+    Test.ensureTrue(baseView.materialized == null, "baseView materialized remains null after reads");
+    Test.ensureTrue(osv.materialized == null, "osv materialized remains null after reads");
+  }
+
+  @org.junit.jupiter.api.Test
+  void testOffsetScaleViewFlattening() {
+    DoubleArray da = new DoubleArray(new double[] {1.0, 2.0, 3.0, 4.0});
+    PrimitiveView v0 = new PrimitiveView(da, 0, 1, 4);
+
+    // Chain 1: scale by 2, add 10 -> y1 = 2*x + 10
+    PrimitiveArray v1 = v0.scaleAddOffset(2.0, 10.0);
+    // Chain 2: scale by 3, add 5  -> y2 = 3*(2*x + 10) + 5 = 6*x + 35
+    PrimitiveArray v2 = v1.scaleAddOffset(3.0, 5.0);
+
+    Test.ensureTrue(v2 instanceof OffsetScaleView, "v2 is OffsetScaleView");
+    OffsetScaleView osv2 = (OffsetScaleView) v2;
+    Test.ensureEqual(osv2.scale, 6.0, "composed scale = 2*3 = 6");
+    Test.ensureEqual(osv2.offset, 35.0, "composed offset = 3*10 + 5 = 35");
+    Test.ensureEqual(osv2.getDouble(0), 41.0, "v2 getDouble(0) = 6*1 + 35 = 41");
+    Test.ensureEqual(osv2.getDouble(1), 47.0, "v2 getDouble(1) = 6*2 + 35 = 47");
+  }
+
+  @org.junit.jupiter.api.Test
+  void testOffsetScaleViewMaterializeAndMutation() {
+    FloatArray fa = new FloatArray(new float[] {10f, 20f, 30f});
+    PrimitiveView baseView = new PrimitiveView(fa, 0, 1, 3);
+    PrimitiveArray scaled = baseView.scaleAddOffset(PAType.FLOAT, 0.5, 2.0);
+
+    Test.ensureTrue(scaled instanceof OffsetScaleView, "scaled is OffsetScaleView");
+    OffsetScaleView osv = (OffsetScaleView) scaled;
+    Test.ensureTrue(osv.materialized == null, "unmaterialized initially");
+
+    // Mutate an element via setFloat
+    osv.setFloat(1, 99.0f);
+    Test.ensureTrue(osv.materialized != null, "materialized after mutation");
+    Test.ensureEqual(osv.getFloat(0), 7.0f, "osv getFloat(0)");
+    Test.ensureEqual(osv.getFloat(1), 99.0f, "osv getFloat(1) updated");
+    Test.ensureEqual(fa.getFloat(1), 20f, "original array unaltered");
+  }
 }

--- a/src/test/java/com/cohort/array/PrimitiveViewTests.java
+++ b/src/test/java/com/cohort/array/PrimitiveViewTests.java
@@ -232,7 +232,7 @@ class PrimitiveViewTests {
     Test.ensureTrue(v2 instanceof OffsetScaleView, "v2 is OffsetScaleView");
     OffsetScaleView osv2 = (OffsetScaleView) v2;
     Test.ensureEqual(osv2.scale, 6.0, "composed scale = 2*3 = 6");
-    Test.ensureEqual(osv2.offset, 35.0, "composed offset = 3*10 + 5 = 35");
+    Test.ensureEqual(osv2.addOffset, 35.0, "composed offset = 3*10 + 5 = 35");
     Test.ensureEqual(osv2.getDouble(0), 41.0, "v2 getDouble(0) = 6*1 + 35 = 41");
     Test.ensureEqual(osv2.getDouble(1), 47.0, "v2 getDouble(1) = 6*2 + 35 = 47");
   }


### PR DESCRIPTION
Implemented `OffsetScaleView` extending `PrimitiveView` to eliminate unnecessary copy-on-write materializations during linear scale and offset operations ($y = m \cdot x + b$) across ERDDAP array processing routines.

---
*PR created automatically by Jules for task [15601766452137223277](https://jules.google.com/task/15601766452137223277) started by @ChrisJohnNOAA*